### PR TITLE
Cleanup & unify: card display, storage, suggestion system, dashboard & settings

### DIFF
--- a/backend/src/routes/collection.js
+++ b/backend/src/routes/collection.js
@@ -529,6 +529,8 @@ router.get('/stats', async (req, res) => {
     let totalCards = 0;
     let uniqueCards = rows.length;
     let totalValue = 0;
+    let totalSpent = 0;
+    let unsortedCount = 0;
     let nearMintCount = 0;
     let vintageCount = 0;
 
@@ -556,6 +558,8 @@ router.get('/stats', async (req, res) => {
 
       totalCards += qty;
       totalValue += qty * price;
+      totalSpent += qty * (row.purchase_price || 0);
+      if (!row.location_name) unsortedCount += qty;
 
       if (row.condition === 'Near Mint') {
         nearMintCount += qty;
@@ -671,11 +675,36 @@ router.get('/stats', async (req, res) => {
     const mintRate = totalCards > 0 ? parseFloat(((nearMintCount / totalCards) * 100).toFixed(1)) : 0.0;
     const vintageRatio = totalCards > 0 ? parseFloat(((vintageCount / totalCards) * 100).toFixed(1)) : 0.0;
 
+    // Recently added cards (most useful "what did I just add" glance)
+    const recentRows = await db.all(`
+      SELECT c.quantity, c.condition, c.printing, c.language, c.added_at,
+             cc.id as card_id, cc.name, cc.rarity, cc.set_name, cc.number, cc.image_url,
+             cc.price_trend, cc.price_normal, cc.price_holofoil, cc.price_reverse_holofoil
+      FROM collection c
+      JOIN card_cache cc ON c.card_id = cc.id
+      WHERE c.user_id = ?
+      ORDER BY c.added_at DESC
+      LIMIT 6
+    `, [req.user.id]);
+    const recentAdditions = recentRows.map(row => ({ ...row, price_trend: resolveCardPrice(row) }));
+
+    const gainAbs = totalValue - totalSpent;
+    const roi = {
+      abs: parseFloat(gainAbs.toFixed(2)),
+      pct: totalSpent > 0 ? parseFloat(((gainAbs / totalSpent) * 100).toFixed(1)) : null
+    };
+    const avgCardValue = totalCards > 0 ? parseFloat((totalValue / totalCards).toFixed(2)) : 0.0;
+
     res.json({
       summary: {
         totalCards,
         uniqueCards,
         totalValue: parseFloat(totalValue.toFixed(2)),
+        totalSpent: parseFloat(totalSpent.toFixed(2)),
+        roi,
+        avgCardValue,
+        unsortedCount,
+        duplicateCopies: Math.max(totalCards - uniqueCards, 0),
         mintRate,
         vintageRatio,
         change7d: {
@@ -705,6 +734,7 @@ router.get('/stats', async (req, res) => {
       })).sort((a, b) => b.value - a.value).slice(0, 8),
       locations: Object.keys(locationCounts).map(name => ({ name, value: locationCounts[name] })),
       topValuable,
+      recentAdditions,
       setProgress: setProgress.slice(0, 4)
     });
   } catch (error) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -275,7 +275,11 @@ function App() {
       {/* Main Content Area */}
       <main style={{ flex: 1, marginTop: '1rem' }}>
         <ErrorBoundary>
-          {renderContent()}
+          {/* key on activeTab replays the mount animation for a smooth
+              transition instead of a hard swap between views */}
+          <div key={activeTab} className="view-transition">
+            {renderContent()}
+          </div>
         </ErrorBoundary>
       </main>
 

--- a/frontend/src/components/CollectionList.jsx
+++ b/frontend/src/components/CollectionList.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Search, Download, Trash2, Edit2, X, MapPin, LayoutGrid, List, Database, Upload, ChevronDown } from 'lucide-react';
-import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip } from 'recharts';
 import { getCardDisplayName } from '../utils/langHelper';
 import { formatPrice } from '../utils/formatPrice';
 import { CONDITIONS, PRINTINGS, LANGUAGES } from '../utils/cardOptions';
+import { getPrintingBadgeLabel, getPrintingBadgeStyle } from '../utils/cardPrinting';
+import PriceHistoryChart from './PriceHistoryChart';
 import DeckBuilder from './DeckBuilder';
 
 function CollectionList({ statsTrigger, onUpdate, showToast, token, selectedCardFilter, setSelectedCardFilter }) {
@@ -493,13 +494,10 @@ function CollectionList({ statsTrigger, onUpdate, showToast, token, selectedCard
                         fontWeight: 800,
                         padding: '2px 5px',
                         borderRadius: '3px',
-                        background: item.printing.includes('Holo') ? 'rgba(234, 179, 8, 0.9)' : 'rgba(59, 130, 246, 0.9)',
-                        color: '#000',
+                        ...getPrintingBadgeStyle(item.printing),
                         border: '1px solid rgba(255, 255, 255, 0.2)'
                       }}>
-                        {item.printing === 'Reverse Holofoil' ? 'REV' : 
-                         item.printing === 'Holofoil' ? 'HOLO' : 
-                         item.printing === '1st Edition' ? '1ST' : 'PRM'}
+                        {getPrintingBadgeLabel(item.printing)}
                       </span>
                     )}
                   </div>
@@ -562,7 +560,7 @@ function CollectionList({ statsTrigger, onUpdate, showToast, token, selectedCard
                     </td>
                     <td style={{ textAlign: 'right', verticalAlign: 'top', paddingTop: '0.6rem' }}>
                       <div style={{ fontWeight: 700, color: '#fff', fontSize: '0.85rem' }}>x{item.quantity}</div>
-                      <div style={{ fontSize: '0.7rem', color: 'var(--accent-yellow)', fontWeight: 600 }}>${(item.price_trend || 0).toFixed(2)}</div>
+                      <div style={{ fontSize: '0.7rem', color: 'var(--accent-yellow)', fontWeight: 600 }}>${formatPrice(item.price_trend)}</div>
                     </td>
                   </tr>
                 ))}
@@ -814,33 +812,7 @@ function CollectionList({ statsTrigger, onUpdate, showToast, token, selectedCard
               </div>
 
               {/* Price History Area Chart */}
-              {loadingHistory ? (
-                <div className="spinner" style={{ height: '30px', margin: '0.5rem auto' }}></div>
-              ) : priceHistory.length > 0 && (
-                <div style={{ width: '100%', background: 'rgba(0,0,0,0.15)', padding: '0.6rem', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-glass)' }}>
-                  <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', fontWeight: 700, textTransform: 'uppercase', marginBottom: '6px', letterSpacing: '0.05em' }}>Price History (30 Days)</div>
-                  <div style={{ width: '100%', height: '65px' }}>
-                    <ResponsiveContainer width="100%" height="100%">
-                      <AreaChart data={priceHistory} margin={{ top: 5, right: 0, left: -20, bottom: 0 }}>
-                        <defs>
-                          <linearGradient id="priceGlow" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="5%" stopColor="var(--accent-yellow)" stopOpacity={0.25}/>
-                            <stop offset="95%" stopColor="var(--accent-yellow)" stopOpacity={0}/>
-                          </linearGradient>
-                        </defs>
-                        <XAxis dataKey="recorded_at" hide />
-                        <YAxis domain={['auto', 'auto']} stroke="var(--text-secondary)" style={{ fontSize: '0.55rem' }} width={30} />
-                        <Tooltip 
-                          contentStyle={{ background: 'rgba(0,0,0,0.85)', border: '1px solid var(--border-glass)', borderRadius: '4px', fontSize: '0.7rem', color: '#fff' }}
-                          labelFormatter={(label) => new Date(label).toLocaleDateString()}
-                          formatter={(val) => [`$${val.toFixed(2)}`, 'Market']}
-                        />
-                        <Area type="monotone" dataKey="price" stroke="var(--accent-yellow)" strokeWidth={1.5} fillOpacity={1} fill="url(#priceGlow)" />
-                      </AreaChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
-              )}
+              <PriceHistoryChart data={priceHistory} loading={loadingHistory} />
 
               {/* Specifications Details Grid */}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.6rem 1rem', background: 'rgba(255,255,255,0.01)', border: '1px solid var(--border-glass)', padding: '0.75rem', borderRadius: 'var(--radius-sm)', fontSize: '0.75rem' }}>

--- a/frontend/src/components/CollectionList.jsx
+++ b/frontend/src/components/CollectionList.jsx
@@ -3,7 +3,7 @@ import { Search, Download, Trash2, Edit2, X, MapPin, LayoutGrid, List, Database,
 import { getCardDisplayName } from '../utils/langHelper';
 import { formatPrice } from '../utils/formatPrice';
 import { CONDITIONS, PRINTINGS, LANGUAGES } from '../utils/cardOptions';
-import { getPrintingBadgeLabel, getPrintingBadgeStyle } from '../utils/cardPrinting';
+import { getPrintingBadgeLabel, getPrintingBadgeStyle, getFoilOverlayClass } from '../utils/cardPrinting';
 import PriceHistoryChart from './PriceHistoryChart';
 import DeckBuilder from './DeckBuilder';
 
@@ -457,9 +457,12 @@ function CollectionList({ statsTrigger, onUpdate, showToast, token, selectedCard
             const glowClass = isUltra ? 'rarity-glow-ultra' : '';
 
             return (
-              <div key={item.entry_id} className="tcg-card" onClick={() => setInspectorCard(item)}>
+              <div key={item.entry_id} className="tcg-card tilt-card-wrapper" onClick={() => setInspectorCard(item)}>
                 <div className={`tcg-card-inner ${glowClass}`}>
                   <img src={item.image_url} alt={item.name} className="tcg-card-image" loading="lazy" />
+                  {getFoilOverlayClass(item.printing) && (
+                    <div className={getFoilOverlayClass(item.printing)} style={{ borderRadius: 'var(--radius-sm)' }} />
+                  )}
                   <div className="tcg-card-quantity-tag">x{item.quantity}</div>
                   
                   {/* Overlay Tags */}
@@ -529,14 +532,10 @@ function CollectionList({ statsTrigger, onUpdate, showToast, token, selectedCard
                   <tr key={item.entry_id}>
                     <td>
                       <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                        <div style={{ position: 'relative', width: '36px', height: '50px', flexShrink: 0 }}>
+                        <div style={{ position: 'relative', width: '36px', height: '50px', flexShrink: 0, overflow: 'hidden', borderRadius: '4px' }}>
                           <img src={item.image_url} alt={item.name} className="collection-row-thumbnail" style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '4px' }} />
-                          {((item.printing || '').toLowerCase().includes('holo') || (item.printing || '').toLowerCase().includes('foil')) && (
-                            <div style={{
-                              position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
-                              background: 'linear-gradient(135deg, rgba(255,255,255,0.25) 0%, transparent 50%, rgba(255,255,255,0.15) 100%)',
-                              pointerEvents: 'none', zIndex: 2, mixBlendMode: 'overlay', borderRadius: '4px'
-                            }} />
+                          {getFoilOverlayClass(item.printing) && (
+                            <div className={getFoilOverlayClass(item.printing)} style={{ borderRadius: '4px' }} />
                           )}
                         </div>
                         <div style={{ minWidth: 0, flex: 1 }}>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -3,6 +3,7 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pi
 import { TrendingUp, Coins, Library, Compass, Trophy, Plus, ArrowUpRight, Sparkles, X } from 'lucide-react';
 import { getCardDisplayName } from '../utils/langHelper';
 import { formatPrice } from '../utils/formatPrice';
+import PriceHistoryChart from './PriceHistoryChart';
 
 const COLORS = [
   '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', 
@@ -511,26 +512,7 @@ function Dashboard({ statsTrigger, onNavigate }) {
               </div>
 
               {/* Price History Area Chart */}
-              {loadingCardHistory ? (
-                <div className="spinner" style={{ height: '30px', margin: '0.5rem auto' }}></div>
-              ) : cardHistory.length > 0 && (
-                <div style={{ width: '100%', height: '80px', background: 'rgba(0,0,0,0.15)', padding: '0.5rem', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-glass)' }}>
-                  <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', fontWeight: 600, textTransform: 'uppercase', marginBottom: '4px', letterSpacing: '0.05em' }}>Price Trend History (30 Days)</div>
-                  <div style={{ width: '100%', height: '50px' }}>
-                    <ResponsiveContainer width="100%" height="100%">
-                      <AreaChart data={cardHistory} margin={{ top: 0, right: 0, left: -25, bottom: 0 }}>
-                        <XAxis dataKey="recorded_at" hide />
-                        <YAxis stroke="var(--text-secondary)" style={{ fontSize: '0.6rem' }} />
-                        <Tooltip 
-                          contentStyle={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border-glass)', fontSize: '0.7rem' }}
-                          formatter={(v) => [`$${v}`, 'Price']}
-                        />
-                        <Area type="monotone" dataKey="price" stroke="var(--accent-yellow)" strokeWidth={1.5} fill="rgba(234,179,8,0.1)" />
-                      </AreaChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
-              )}
+              <PriceHistoryChart data={cardHistory} loading={loadingCardHistory} title="Price Trend History (30 Days)" height={120} />
 
               <div style={{ borderTop: '1px solid var(--border-glass)', paddingTop: '0.75rem', fontSize: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
                 <div><span style={{ color: 'var(--text-muted)' }}>Condition:</span> <span style={{ color: '#fff' }}>{inspectorCard.condition}</span></div>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, Legend, AreaChart, Area } from 'recharts';
-import { TrendingUp, Coins, Library, Compass, Trophy, Plus, ArrowUpRight, Sparkles, X } from 'lucide-react';
+import { TrendingUp, Coins, Library, Trophy, Plus, ArrowUpRight, X } from 'lucide-react';
 import { getCardDisplayName } from '../utils/langHelper';
 import { formatPrice } from '../utils/formatPrice';
 import PriceHistoryChart from './PriceHistoryChart';
@@ -133,7 +133,7 @@ function Dashboard({ statsTrigger, onNavigate }) {
     );
   }
 
-  const { summary, types, rarities, sets, locations, topValuable, setProgress } = stats;
+  const { summary, types, rarities, sets, topValuable, recentAdditions = [], setProgress } = stats;
 
   const typeChartData = types.map(t => ({
     name: t.name,
@@ -189,25 +189,37 @@ function Dashboard({ statsTrigger, onNavigate }) {
           })()}
         </div>
 
-        {/* Mint Rate */}
+        {/* Total Invested (cost basis) */}
         <div className="glass-panel metric-card">
           <div className="metric-header">
-            <span>Mint Rate</span>
-            <Sparkles size={18} style={{ color: 'var(--accent-yellow)' }} />
+            <span>Total Invested</span>
+            <Coins size={18} style={{ color: 'var(--accent-yellow)' }} />
           </div>
-          <div className="metric-value">{summary.mintRate || 0}%</div>
-          <div className="metric-footer">Near Mint condition ratio</div>
+          <div className="metric-value">${(summary.totalSpent || 0).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2})}</div>
+          <div className="metric-footer">
+            <span>Avg ${formatPrice(summary.avgCardValue)} / card</span>
+          </div>
         </div>
 
-        {/* Vintage Ratio */}
-        <div className="glass-panel metric-card">
-          <div className="metric-header">
-            <span>Vintage Ratio</span>
-            <Coins size={18} />
-          </div>
-          <div className="metric-value">{summary.vintageRatio || 0}%</div>
-          <div className="metric-footer">Classic vintage set ratio</div>
-        </div>
+        {/* Unrealized Gain / ROI */}
+        {(() => {
+          const roi = summary.roi || { abs: 0, pct: null };
+          const isPositive = (roi.abs || 0) >= 0;
+          return (
+            <div className="glass-panel metric-card">
+              <div className="metric-header">
+                <span>Unrealized Gain</span>
+                <ArrowUpRight size={18} style={{ color: isPositive ? '#22c55e' : '#ef4444', transform: isPositive ? 'none' : 'rotate(90deg)' }} />
+              </div>
+              <div className="metric-value" style={{ color: isPositive ? '#22c55e' : '#ef4444' }}>
+                {isPositive ? '+' : '−'}${Math.abs(roi.abs || 0).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2})}
+              </div>
+              <div className="metric-footer">
+                <span>{roi.pct === null ? 'Set purchase prices to track ROI' : `${isPositive ? '+' : ''}${roi.pct}% vs cost basis`}</span>
+              </div>
+            </div>
+          );
+        })()}
 
         {/* Total Cards count */}
         <div className="glass-panel metric-card">
@@ -217,7 +229,7 @@ function Dashboard({ statsTrigger, onNavigate }) {
           </div>
           <div className="metric-value">{summary.totalCards}</div>
           <div className="metric-footer">
-            <span>{summary.uniqueCards} unique card styles</span>
+            <span>{summary.uniqueCards} unique{summary.unsortedCount > 0 ? ` • ${summary.unsortedCount} unsorted` : ''}</span>
           </div>
         </div>
       </div>
@@ -394,6 +406,38 @@ function Dashboard({ statsTrigger, onNavigate }) {
               ))}
             </div>
           </div>
+
+          {/* Recent Additions */}
+          {recentAdditions.length > 0 && (
+            <div className="glass-panel" style={{ flex: 1 }}>
+              <h3 className="chart-title" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <Plus size={18} style={{ color: 'var(--accent-blue)' }} />
+                Recent Additions
+              </h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem', marginTop: '1.25rem' }}>
+                {recentAdditions.map((card, idx) => (
+                  <div
+                    key={idx}
+                    onClick={() => setInspectorCard(card)}
+                    style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', background: 'rgba(255, 255, 255, 0.02)', padding: '0.5rem', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-glass)', cursor: 'pointer', transition: 'all 0.2s ease' }}
+                    className="dashboard-card-clickable"
+                  >
+                    <img src={card.image_url} alt={card.name} style={{ width: '34px', aspectRatio: 0.718, objectFit: 'cover', borderRadius: '4px' }} />
+                    <div style={{ flex: 1, overflow: 'hidden' }}>
+                      <div style={{ fontWeight: 700, fontSize: '0.85rem', color: '#fff', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                        {getCardDisplayName(card.name, card.language)}
+                      </div>
+                      <div style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{card.set_name} • #{card.number}</div>
+                    </div>
+                    <div style={{ textAlign: 'right' }}>
+                      <div style={{ fontWeight: 700, color: 'var(--accent-yellow)', fontSize: '0.8rem' }}>${formatPrice(card.price_trend)}</div>
+                      <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)' }}>{card.added_at ? new Date(card.added_at).toLocaleDateString() : ''}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Set Completion progress tracker */}
           {setProgress.length > 0 && (

--- a/frontend/src/components/LocationManager.jsx
+++ b/frontend/src/components/LocationManager.jsx
@@ -43,8 +43,12 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
   const [editMaxPages, setEditMaxPages] = useState(30);
   const [editPageStyle, setEditPageStyle] = useState('3x3');
   const [editMaxRows, setEditMaxRows] = useState(3);
+  const [editMaxRowsStr, setEditMaxRowsStr] = useState('3'); // string version to allow clearing
   const [editMaxCapacity, setEditMaxCapacity] = useState(1000);
   const [editFoilSorting, setEditFoilSorting] = useState('normals_first');
+  const [editRowCapacity, setEditRowCapacity] = useState(40); // cards per row for box
+  const [editRowCapacityStr, setEditRowCapacityStr] = useState('40');
+  const [editAssignedSets, setEditAssignedSets] = useState(''); // newline-separated set names
 
   // Binder Grid Visualizer states
   const [viewMode, setViewMode] = useState('grid'); // Defaults to 'grid' (no list view)
@@ -62,7 +66,9 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
   const [unsortedSortOrder, setUnsortedSortOrder] = useState('name-asc');
   const [unsortedViewMode, setUnsortedViewMode] = useState('list'); // 'list' or 'assistant'
   const [assistantIndex, setAssistantIndex] = useState(0);
-  const [assistantHighlightRow, setAssistantHighlightRow] = useState(null); // NEW: highlighted row for box visualizer
+  const [assistantHighlightRow, setAssistantHighlightRow] = useState(null);
+  const [assistantHighlightPos, setAssistantHighlightPos] = useState(null); // NEW: highlighted position within row
+  const [expandedRow, setExpandedRow] = useState(null); // NEW: which row is expanded in box visualizer
   const [unsortedDateFilter, setUnsortedDateFilter] = useState('all');
   const [carouselTouchStartIndex, setCarouselTouchStartIndex] = useState(0);
   
@@ -1407,7 +1413,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
       const maxBinderCapacity = maxPages * pocketsCount;
 
       const maxRows = selectedLoc.max_rows || 3;
-      const maxBoxCapacity = maxRows * 40; // 40 cards per row max
+      const rowCapacity = parseAdvancedConfig(selectedLoc).rowCapacity || 40;
+      const maxBoxCapacity = maxRows * rowCapacity;
 
       let excessCount = 0;
 
@@ -1430,8 +1437,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
           }
         } else if (selectedLoc.type === 'Box' || selectedLoc.type === 'Toploader Box' || selectedLoc.type === 'Graded Slab Box' || selectedLoc.type === 'Display Shelf / Stand') {
           if (index < maxBoxCapacity) {
-            const rowNum = Math.floor(index / 40) + 1;
-            const seq = (index % 40) + 1;
+            const rowNum = Math.floor(index / rowCapacity) + 1;
+            const seq = (index % rowCapacity) + 1;
             sub1 = `Row ${rowNum}`;
             sub2 = String(seq);
           } else {
@@ -1761,6 +1768,21 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
 
   const handleUpdateLocation = async () => {
     if (!editName) return;
+
+    // Merge existing config with new box-specific fields
+    const existingConfig = parseAdvancedConfig(selectedLoc);
+    const isBoxType = (editType === 'Box' || editType === 'Toploader Box' || editType === 'Graded Slab Box' || editType === 'Display Shelf / Stand');
+    let newDescription = selectedLoc.description || '';
+    if (isBoxType) {
+      const assignedSetsArray = editAssignedSets.trim() ? editAssignedSets.split('\n').map(s => s.trim()).filter(Boolean) : [];
+      const updatedConfig = {
+        ...existingConfig,
+        rowCapacity: editRowCapacity || 40,
+        assignedSets: assignedSetsArray
+      };
+      newDescription = JSON.stringify(updatedConfig);
+    }
+
     try {
       const response = await fetch(`/api/locations/${selectedLoc.id}`, {
         method: 'PUT',
@@ -1768,11 +1790,12 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
         body: JSON.stringify({
           name: editName,
           type: editType,
+          description: newDescription,
           sort_order: editSortOrder,
           max_pages: (editType === 'Binder' || editType === 'Toploader Binder') ? parseInt(editMaxPages, 10) : 30,
           page_style: (editType === 'Binder' || editType === 'Toploader Binder') ? editPageStyle : '3x3',
-          max_rows: (editType === 'Box' || editType === 'Toploader Box' || editType === 'Graded Slab Box' || editType === 'Display Shelf / Stand') ? parseInt(editMaxRows, 10) : 3,
-          max_capacity: (editType !== 'Binder' && editType !== 'Toploader Binder' && editType !== 'Box' && editType !== 'Toploader Box' && editType !== 'Graded Slab Box' && editType !== 'Display Shelf / Stand') ? parseInt(editMaxCapacity, 10) : 1000,
+          max_rows: isBoxType ? (parseInt(editMaxRowsStr, 10) || editMaxRows || 3) : 3,
+          max_capacity: (editType !== 'Binder' && editType !== 'Toploader Binder' && !isBoxType) ? parseInt(editMaxCapacity, 10) : 1000,
           foil_sorting: editFoilSorting
         })
       });
@@ -1838,8 +1861,9 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
           }
         } else if (selectedLoc.type === 'Box' || selectedLoc.type === 'Toploader Box' || selectedLoc.type === 'Graded Slab Box' || selectedLoc.type === 'Display Shelf / Stand') {
           const maxRows = selectedLoc.max_rows || 3;
-          const rowNum = Math.floor(targetIndex / 40) + 1;
-          const seq = (targetIndex % 40) + 1;
+          const rowCapacity = config.rowCapacity || 40;
+          const rowNum = Math.floor(targetIndex / rowCapacity) + 1;
+          const seq = (targetIndex % rowCapacity) + 1;
 
           if (rowNum <= maxRows) {
             return {
@@ -1878,10 +1902,11 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
       }
     } else if (selectedLoc.type === 'Box' || selectedLoc.type === 'Toploader Box' || selectedLoc.type === 'Graded Slab Box' || selectedLoc.type === 'Display Shelf / Stand') {
       const maxRows = selectedLoc.max_rows || 3;
+      const rowCapacity = config.rowCapacity || 40;
       for (let r = 1; r <= maxRows; r++) {
         const rowName = `Row ${r}`;
         const existingInRow = locationCards.filter(c => c.sub_location_1 === rowName);
-        if (existingInRow.length < 40) {
+        if (existingInRow.length < rowCapacity) {
           const nextSeq = existingInRow.length + 1;
           return { sub1: rowName, sub2: String(nextSeq), label: `${rowName}, Pos ${nextSeq}` };
         }
@@ -2041,9 +2066,17 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                       setEditSortOrder(selectedLoc.sort_order || 'custom');
                       setEditMaxPages(selectedLoc.max_pages || 30);
                       setEditPageStyle(selectedLoc.page_style || '3x3');
-                      setEditMaxRows(selectedLoc.max_rows || 3);
+                      const rows = selectedLoc.max_rows || 3;
+                      setEditMaxRows(rows);
+                      setEditMaxRowsStr(String(rows));
                       setEditMaxCapacity(selectedLoc.max_capacity || 1000);
                       setEditFoilSorting(selectedLoc.foil_sorting || 'normals_first');
+                      // Load box-specific config from description JSON
+                      const cfg = parseAdvancedConfig(selectedLoc);
+                      const rowCap = cfg.rowCapacity || 40;
+                      setEditRowCapacity(rowCap);
+                      setEditRowCapacityStr(String(rowCap));
+                      setEditAssignedSets((cfg.assignedSets || []).join('\n'));
                       setIsEditing(true);
                     }}
                     style={{ width: '26px', height: '26px', padding: 0, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.8rem' }}
@@ -2378,7 +2411,7 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                                     borderBottomLeftRadius: '4px',
                                     borderBottomRightRadius: '4px'
                                   }}>
-                                    {getCardDisplayName(card.name, card.language)} (x{card.quantity})
+                                    {getCardDisplayName(card.name, card.language)}{card.quantity > 1 ? ` ×${card.quantity}` : ''}
                                   </div>
                                 </div>
                               ) : (
@@ -3320,17 +3353,64 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
 
             {/* Box-specific fields */}
             {(editType === 'Box' || editType === 'Toploader Box' || editType === 'Graded Slab Box' || editType === 'Display Shelf / Stand') && (
-              <div className="form-group" style={{ marginBottom: 0 }}>
-                <label style={{ fontSize: '0.65rem', color: 'var(--text-secondary)', display: 'block', marginBottom: '2px' }}>Rows / Shelves Count</label>
-                <input 
-                  type="number" 
-                  className="input-control" 
-                  value={editMaxRows} 
-                  onChange={(e) => setEditMaxRows(parseInt(e.target.value, 10) || 3)} 
-                  min="1" max="20"
-                  style={{ padding: '0.35rem 0.5rem', fontSize: '0.75rem' }}
-                />
-              </div>
+              <>
+                <div className="form-group" style={{ marginBottom: 0 }}>
+                  <label style={{ fontSize: '0.65rem', color: 'var(--text-secondary)', display: 'block', marginBottom: '2px' }}>Rows / Shelves Count</label>
+                  <input 
+                    type="text"
+                    inputMode="numeric"
+                    className="input-control" 
+                    value={editMaxRowsStr}
+                    onChange={(e) => {
+                      const raw = e.target.value.replace(/[^0-9]/g, '');
+                      setEditMaxRowsStr(raw);
+                      const parsed = parseInt(raw, 10);
+                      if (!isNaN(parsed) && parsed >= 1 && parsed <= 20) setEditMaxRows(parsed);
+                    }}
+                    onBlur={() => {
+                      const parsed = parseInt(editMaxRowsStr, 10);
+                      if (isNaN(parsed) || parsed < 1) { setEditMaxRows(3); setEditMaxRowsStr('3'); }
+                      else if (parsed > 20) { setEditMaxRows(20); setEditMaxRowsStr('20'); }
+                    }}
+                    placeholder="e.g. 3"
+                    style={{ padding: '0.35rem 0.5rem', fontSize: '0.75rem' }}
+                  />
+                </div>
+                <div className="form-group" style={{ marginBottom: 0 }}>
+                  <label style={{ fontSize: '0.65rem', color: 'var(--text-secondary)', display: 'block', marginBottom: '2px' }}>Cards Per Row (Capacity)</label>
+                  <input 
+                    type="text"
+                    inputMode="numeric"
+                    className="input-control" 
+                    value={editRowCapacityStr}
+                    onChange={(e) => {
+                      const raw = e.target.value.replace(/[^0-9]/g, '');
+                      setEditRowCapacityStr(raw);
+                      const parsed = parseInt(raw, 10);
+                      if (!isNaN(parsed) && parsed >= 1) setEditRowCapacity(parsed);
+                    }}
+                    onBlur={() => {
+                      const parsed = parseInt(editRowCapacityStr, 10);
+                      if (isNaN(parsed) || parsed < 1) { setEditRowCapacity(40); setEditRowCapacityStr('40'); }
+                    }}
+                    placeholder="e.g. 40"
+                    style={{ padding: '0.35rem 0.5rem', fontSize: '0.75rem' }}
+                  />
+                  <span style={{ fontSize: '0.6rem', color: 'var(--text-muted)', marginTop: '2px', display: 'block' }}>How many cards physically fit in each row</span>
+                </div>
+                <div className="form-group" style={{ marginBottom: 0 }}>
+                  <label style={{ fontSize: '0.65rem', color: 'var(--text-secondary)', display: 'block', marginBottom: '2px' }}>Assigned Sets (one per line)</label>
+                  <textarea
+                    className="input-control"
+                    value={editAssignedSets}
+                    onChange={(e) => setEditAssignedSets(e.target.value)}
+                    placeholder={"e.g.\nBase Set\nJungle\nFossil"}
+                    rows={4}
+                    style={{ padding: '0.35rem 0.5rem', fontSize: '0.7rem', resize: 'vertical', minHeight: '70px', fontFamily: 'inherit', lineHeight: 1.4 }}
+                  />
+                  <span style={{ fontSize: '0.6rem', color: 'var(--text-muted)', marginTop: '2px', display: 'block' }}>The assistant uses these sets to recommend this box for matching cards</span>
+                </div>
+              </>
             )}
 
             {/* Capacity-specific fields */}

--- a/frontend/src/components/LocationManager.jsx
+++ b/frontend/src/components/LocationManager.jsx
@@ -5,6 +5,24 @@ import { getCardRarityBorder, getRarityBadgeStyle, getRarityBadgeLabel } from '.
 import { sortCardsByOrder } from '../utils/cardSort';
 import { getPageNum, getSlotNum } from '../utils/locationCoords';
 import { CONDITIONS, PRINTINGS, LANGUAGES } from '../utils/cardOptions';
+import { getPrintingBadgeLabel, getPrintingBadgeStyle } from '../utils/cardPrinting';
+import { buildLocationProfiles, suggestBestContainer } from '../utils/containerSuggest';
+
+// Shared corner badge for a card's finish (Holo / Rev / 1st / Promo). Colors and
+// label come from the single source of truth so Storage matches Collection.
+function PrintingBadge({ printing, style }) {
+  const label = getPrintingBadgeLabel(printing);
+  if (!label) return null;
+  return (
+    <span style={{
+      position: 'absolute', top: '4px', right: '4px',
+      fontSize: '0.55rem', fontWeight: 900, letterSpacing: '0.05em',
+      padding: '1px 5px', borderRadius: '3px', zIndex: 10,
+      boxShadow: '0 1px 3px rgba(0,0,0,0.5)', textTransform: 'uppercase',
+      ...getPrintingBadgeStyle(printing), ...style
+    }}>{label}</span>
+  );
+}
 
 function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId, setSelectedLocationId, setSelectedCardFilter, setActiveTab }) {
   const isMobile = typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
@@ -62,6 +80,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
   
   // Unsorted Cards states
   const [unsortedCards, setUnsortedCards] = useState([]);
+  const [allCards, setAllCards] = useState([]); // full collection, for cross-location suggestions
+  const locationProfiles = useMemo(() => buildLocationProfiles(allCards), [allCards]);
   const [unsortedSearch, setUnsortedSearch] = useState('');
   const [unsortedSortOrder, setUnsortedSortOrder] = useState('name-asc');
   const [unsortedViewMode, setUnsortedViewMode] = useState('list'); // 'list' or 'assistant'
@@ -1037,41 +1057,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                   {/* Shiny holo overlay */}
                   {card.printing === 'Holofoil' && <div className="holo-shine-overlay" style={{ borderRadius: '8px' }} />}
                   {card.printing === 'Reverse Holofoil' && <div className="reverse-holo-shine-overlay" style={{ borderRadius: '8px' }} />}
-                  {/* Holo / Rev Holo text badge indicators */}
-                  {card.printing === 'Holofoil' && (
-                    <span style={{
-                      position: 'absolute',
-                      top: '4px',
-                      right: '4px',
-                      background: 'rgba(217, 119, 6, 0.95)',
-                      color: '#fff',
-                      fontSize: '0.55rem',
-                      fontWeight: 900,
-                      letterSpacing: '0.05em',
-                      padding: '1px 4px',
-                      borderRadius: '3px',
-                      zIndex: 10,
-                      boxShadow: '0 1px 3px rgba(0,0,0,0.5)',
-                      textTransform: 'uppercase'
-                    }}>Holo</span>
-                  )}
-                  {card.printing === 'Reverse Holofoil' && (
-                    <span style={{
-                      position: 'absolute',
-                      top: '4px',
-                      right: '4px',
-                      background: 'rgba(75, 85, 99, 0.95)',
-                      color: '#fff',
-                      fontSize: '0.55rem',
-                      fontWeight: 900,
-                      letterSpacing: '0.05em',
-                      padding: '1px 4px',
-                      borderRadius: '3px',
-                      zIndex: 10,
-                      boxShadow: '0 1px 3px rgba(0,0,0,0.5)',
-                      textTransform: 'uppercase'
-                    }}>Rev Holo</span>
-                  )}
+                  {/* Finish badge (shared style) */}
+                  <PrintingBadge printing={card.printing} />
                   <div style={{
                     position: 'absolute',
                     bottom: 0, left: 0, right: 0,
@@ -1242,7 +1229,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
       const response = await fetch('/api/collection');
       if (response.ok) {
         const allCards = await response.json();
-        
+        setAllCards(allCards);
+
         // Unsorted cards: location_id is null or empty
         const unsorted = allCards.filter(c => !c.location_id);
         setUnsortedCards(unsorted);
@@ -2342,40 +2330,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                                   {/* Shiny holo overlay */}
                                   {card.printing === 'Holofoil' && <div className="holo-shine-overlay" style={{ borderRadius: '8px' }} />}
                                   {card.printing === 'Reverse Holofoil' && <div className="reverse-holo-shine-overlay" style={{ borderRadius: '8px' }} />}
-                                  {/* Holo / Rev Holo text badge indicators */}
-                                  {card.printing === 'Holofoil' && (
-                                    <span style={{
-                                      position: 'absolute',
-                                      top: '4px',
-                                      right: '4px',
-                                      background: 'rgba(217, 119, 6, 0.95)',
-                                      color: '#fff',
-                                      fontSize: '0.55rem',
-                                      fontWeight: 900,
-                                      letterSpacing: '0.05em',
-                                      padding: '1px 4px',
-                                      borderRadius: '3px',
-                                      zIndex: 10,
-                                      boxShadow: '0 1px 3px rgba(0,0,0,0.5)',
-                                      textTransform: 'uppercase'
-                                    }}>Holo</span>
-                                  )}
-                                  {card.printing === 'Reverse Holofoil' && (
-                                    <span style={{
-                                      position: 'absolute',
-                                      top: '4px',
-                                      right: '4px',
-                                      background: 'rgba(75, 85, 99, 0.95)',
-                                      color: '#fff',
-                                      fontSize: '0.55rem',
-                                      fontWeight: 900,
-                                      letterSpacing: '0.05em',
-                                      padding: '1px 4px',
-                                      borderRadius: '3px',
-                                      zIndex: 10,
-                                      boxShadow: '0 1px 3px rgba(0,0,0,0.5)',
-                                    }}>Rev Holo</span>
-                                  )}
+                                  {/* Finish badge (shared style) */}
+                                  <PrintingBadge printing={card.printing} />
                                   
                                   {/* Card Rarity Indicator Badge */}
                                   <span style={{
@@ -2565,6 +2521,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
               }
 
               const recommended = findNextRecommendedSlot(card);
+              const bestContainer = suggestBestContainer(card, locations, locationProfiles);
+              const suggestsElsewhere = bestContainer && bestContainer.location.id !== selectedLoc?.id;
 
               return (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
@@ -2629,6 +2587,24 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                         <div>Cond: <strong style={{ color: '#fff' }}>{card.condition}</strong></div>
                         <div>Value: <strong style={{ color: 'var(--accent-yellow)' }}>${(card.price_trend || 0).toFixed(2)}</strong></div>
                       </div>
+
+                      {suggestsElsewhere && (
+                        <div style={{ background: 'rgba(59, 130, 246, 0.08)', border: '1px solid rgba(59, 130, 246, 0.25)', padding: '0.4rem 0.5rem', borderRadius: '4px', display: 'flex', flexDirection: 'column', gap: '3px' }}>
+                          <span style={{ fontSize: '0.55rem', color: 'var(--accent-blue)', textTransform: 'uppercase', fontWeight: 700, letterSpacing: '0.04em' }}>💡 Best fit: {bestContainer.location.name}</span>
+                          <span style={{ fontSize: '0.6rem', color: 'var(--text-secondary)', fontStyle: 'italic' }}>{bestContainer.reason} • {bestContainer.free} free</span>
+                          <button
+                            type="button"
+                            className="btn btn-secondary"
+                            onClick={async () => {
+                              await handleRelocateCardToContainer(card.entry_id, bestContainer.location);
+                              if (idx >= queue.length - 1) setAssistantIndex(0);
+                            }}
+                            style={{ width: '100%', marginTop: '2px', fontSize: '0.62rem', padding: '0.22rem', height: '22px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                          >
+                            Send to {bestContainer.location.name}
+                          </button>
+                        </div>
+                      )}
 
                       {recommended ? (() => {
                         const sortLabels = { 'custom': 'Custom', 'name-asc': 'A-Z', 'price-desc': 'Value', 'set-number': 'Set & Number', 'set-number-printing': 'Set/Number/Printing', 'type-name': 'Energy Type' };
@@ -3515,9 +3491,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                         </span>
                         <span style={{
                           fontSize: '0.55rem',
-                          background: c.printing === 'Holofoil' ? 'rgba(217, 119, 6, 0.95)' : c.printing === 'Reverse Holofoil' ? 'rgba(75, 85, 99, 0.95)' : 'rgba(255,255,255,0.05)',
-                          color: '#fff',
-                          padding: '1px 4px',
+                          ...getPrintingBadgeStyle(c.printing),
+                          padding: '1px 5px',
                           borderRadius: '3px',
                           fontWeight: 700,
                           textTransform: 'uppercase'

--- a/frontend/src/components/PriceHistoryChart.jsx
+++ b/frontend/src/components/PriceHistoryChart.jsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { formatPrice } from '../utils/formatPrice';
+
+// Shared, properly-proportioned price-history chart. Replaces the two cramped
+// copies (CollectionList inspector at 65px, Dashboard inspector at 50px) that
+// clipped their axis labels. Give it real vertical room and let the YAxis
+// reserve enough width for "$1,234" style ticks.
+export default function PriceHistoryChart({
+  data = [],
+  loading = false,
+  height = 150,
+  title = 'Price History (30 Days)',
+}) {
+  const { pctChange, absChange } = useMemo(() => {
+    if (!data || data.length < 2) return { pctChange: null, absChange: null };
+    const first = data[0]?.price ?? 0;
+    const last = data[data.length - 1]?.price ?? 0;
+    const abs = last - first;
+    const pct = first > 0 ? (abs / first) * 100 : 0;
+    return { pctChange: pct, absChange: abs };
+  }, [data]);
+
+  if (loading) {
+    return <div className="spinner" style={{ height: '30px', margin: '0.75rem auto' }} />;
+  }
+  if (!data || data.length === 0) return null;
+
+  const up = (pctChange ?? 0) >= 0;
+  const trendColor = up ? '#22c55e' : '#ef4444';
+
+  return (
+    <div style={{
+      width: '100%',
+      background: 'rgba(0,0,0,0.15)',
+      padding: '0.75rem',
+      borderRadius: 'var(--radius-sm)',
+      border: '1px solid var(--border-glass)'
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '6px' }}>
+        <span style={{ fontSize: '0.65rem', color: 'var(--text-muted)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          {title}
+        </span>
+        {pctChange !== null && (
+          <span style={{ fontSize: '0.7rem', fontWeight: 800, color: trendColor }}>
+            {up ? '▲' : '▼'} {up ? '+' : ''}${formatPrice(Math.abs(absChange))} ({up ? '+' : '−'}{Math.abs(pctChange).toFixed(1)}%)
+          </span>
+        )}
+      </div>
+      <div style={{ width: '100%', height: `${height}px` }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="priceGlow" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--accent-yellow)" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="var(--accent-yellow)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
+            <XAxis dataKey="recorded_at" hide />
+            <YAxis
+              domain={['auto', 'auto']}
+              stroke="var(--text-secondary)"
+              style={{ fontSize: '0.6rem' }}
+              width={48}
+              tickFormatter={(v) => `$${formatPrice(v)}`}
+            />
+            <Tooltip
+              contentStyle={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-glass)', borderRadius: '8px', fontSize: '0.75rem' }}
+              labelStyle={{ color: 'var(--text-secondary)' }}
+              formatter={(val) => [`$${formatPrice(val)}`, 'Market']}
+              labelFormatter={(label) => (label ? new Date(label).toLocaleDateString() : '')}
+            />
+            <Area type="monotone" dataKey="price" stroke="var(--accent-yellow)" strokeWidth={1.75} fillOpacity={1} fill="url(#priceGlow)" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { ShieldAlert, Share2, Clipboard, RefreshCw, KeyRound, Check, Database, Download, Upload } from 'lucide-react';
+import { ShieldAlert, Share2, Clipboard, RefreshCw, KeyRound, Check, Database, Download, Upload, Eye, EyeOff } from 'lucide-react';
 
 function Settings({ user, onUpdateUser, showToast }) {
+  const [showApiKey, setShowApiKey] = useState(false);
   const [currentPassword, setCurrentPassword] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -16,6 +17,11 @@ function Settings({ user, onUpdateUser, showToast }) {
   const handleImportFile = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
+
+    if (!window.confirm(`Import "${file.name}"? Cards from this file will be merged into your existing collection. This cannot be undone.`)) {
+      e.target.value = '';
+      return;
+    }
 
     const reader = new FileReader();
     const isJson = file.name.endsWith('.json');
@@ -417,28 +423,39 @@ function Settings({ user, onUpdateUser, showToast }) {
         <div className="glass-panel" style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', borderBottom: '1px solid var(--border-glass)', paddingBottom: '0.75rem' }}>
             <KeyRound size={20} style={{ color: 'var(--accent-red)' }} />
-            <h3 style={{ color: '#fff', fontSize: '1.1rem' }}>Developer API Key</h3>
+            <h3 style={{ color: '#fff', fontSize: '1.1rem' }}>Pokémon TCG API Key</h3>
           </div>
 
           <form onSubmit={handleApiKeyChange} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <div style={{ background: 'rgba(255, 71, 71, 0.03)', border: '1px solid var(--border-glass)', padding: '0.75rem 1rem', borderRadius: 'var(--radius-sm)', fontSize: '0.8rem', color: 'var(--text-secondary)', lineHeight: '1.4' }}>
-              Avoid rate-limit delay tarpits by registering for a free key at <a href="https://dev.pokemontcg.io" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-yellow)', fontWeight: 600 }}>dev.pokemontcg.io</a> and entering it below.
+              Card searches use the free Pokémon TCG API. Adding your own key raises your rate limit so searches stay fast during bulk scanning. Grab a free key at <a href="https://dev.pokemontcg.io" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-yellow)', fontWeight: 600 }}>dev.pokemontcg.io</a> and paste it below. It's optional.
             </div>
 
             <div className="form-group" style={{ marginBottom: 0 }}>
-              <label htmlFor="settings-tcg-api-key">X-Api-Key Header Value</label>
-              <input
-                id="settings-tcg-api-key"
-                type="text"
-                name="tcg-api-key"
-                autoComplete="off"
-                className="input-control"
-                placeholder="e.g. xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                value={tcgApiKey}
-                onChange={(e) => setTcgApiKey(e.target.value)}
-                disabled={apiKeyLoading}
-                style={{ fontFamily: 'monospace' }}
-              />
+              <label htmlFor="settings-tcg-api-key">API Key</label>
+              <div style={{ position: 'relative' }}>
+                <input
+                  id="settings-tcg-api-key"
+                  type={showApiKey ? 'text' : 'password'}
+                  name="tcg-api-key"
+                  autoComplete="off"
+                  className="input-control"
+                  placeholder="e.g. xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  value={tcgApiKey}
+                  onChange={(e) => setTcgApiKey(e.target.value)}
+                  disabled={apiKeyLoading}
+                  style={{ fontFamily: 'monospace', paddingRight: '2.4rem', width: '100%' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowApiKey((v) => !v)}
+                  aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
+                  title={showApiKey ? 'Hide API key' : 'Show API key'}
+                  style={{ position: 'absolute', right: '0.5rem', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', display: 'flex', alignItems: 'center', padding: 0 }}
+                >
+                  {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
             </div>
 
             <button 

--- a/frontend/src/components/SharedCollection.jsx
+++ b/frontend/src/components/SharedCollection.jsx
@@ -3,6 +3,7 @@ import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recha
 import { Search, Trophy, Compass, Library, ShieldAlert, Sparkles, X } from 'lucide-react';
 import { formatPrice } from '../utils/formatPrice';
 import { PRINTINGS } from '../utils/cardOptions';
+import { getFoilOverlayClass, getPrintingBadgeLabel, getPrintingBadgeStyle } from '../utils/cardPrinting';
 
 const COLORS = [
   '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', 
@@ -335,9 +336,17 @@ function SharedCollection({ shareToken }) {
             const glowClass = isUltra ? 'rarity-glow-ultra' : '';
 
             return (
-              <div key={card.entry_id} className="tcg-card" onClick={() => setActiveCard(card)}>
+              <div key={card.entry_id} className="tcg-card tilt-card-wrapper" onClick={() => setActiveCard(card)}>
                 <div className={`tcg-card-inner ${glowClass}`}>
                   <img src={card.image_url} alt={card.name} className="tcg-card-image" loading="lazy" />
+                  {getFoilOverlayClass(card.printing) && (
+                    <div className={getFoilOverlayClass(card.printing)} style={{ borderRadius: 'var(--radius-sm)' }} />
+                  )}
+                  {getPrintingBadgeLabel(card.printing) && (
+                    <span style={{ position: 'absolute', top: '6px', left: '6px', fontSize: '0.6rem', fontWeight: 800, padding: '2px 5px', borderRadius: '3px', zIndex: 6, ...getPrintingBadgeStyle(card.printing) }}>
+                      {getPrintingBadgeLabel(card.printing)}
+                    </span>
+                  )}
                   <div className="tcg-card-quantity-tag">x{card.quantity}</div>
                 </div>
                 <div className="tcg-card-info">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1421,49 +1421,89 @@ button, input, select, textarea {
   font-size: 0.7rem;
 }
 
-/* Premium Holofoil Shimmer Sheen */
-@keyframes holoShimmer {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
+/* ==========================================================================
+   FOIL FINISHES — Holofoil vs Reverse Holofoil are intentionally distinct.
+   Holofoil  = full rainbow prism that drifts continuously (screen blend).
+   Reverse   = cool silver sheen band sweeping over a subtle pinstripe.
+   The continuous motion lives on ::after pseudo-elements so it never fights
+   the JS tilt handler, which drives the element's own background-position.
+   ========================================================================== */
+
+@keyframes holoDrift {
+  to { transform: rotate(360deg); }
+}
+@keyframes foilSweep {
+  0%   { transform: translateX(-120%) skewX(-18deg); }
+  60%, 100% { transform: translateX(320%) skewX(-18deg); }
 }
 
 .holo-shine-overlay {
   position: absolute;
   top: 0; left: 0; right: 0; bottom: 0;
+  overflow: hidden;
+  border-radius: inherit;
   background: linear-gradient(125deg,
     rgba(255, 255, 255, 0) 0%,
-    rgba(255, 0, 128, 0.08) 15%,
-    rgba(128, 0, 255, 0.12) 30%,
-    rgba(0, 128, 255, 0.12) 45%,
-    rgba(0, 255, 128, 0.08) 60%,
-    rgba(255, 255, 0, 0.12) 75%,
+    rgba(255, 0, 128, 0.14) 15%,
+    rgba(128, 0, 255, 0.20) 30%,
+    rgba(0, 128, 255, 0.20) 45%,
+    rgba(0, 255, 128, 0.14) 60%,
+    rgba(255, 255, 0, 0.18) 75%,
     rgba(255, 255, 255, 0) 100%
   );
   background-size: 200% 200%;
   pointer-events: none;
   z-index: 5;
   mix-blend-mode: screen;
-  opacity: 0.3;
+  opacity: 0.5;
   transition: opacity 0.3s ease, background-position 0.05s ease-out;
+}
+.holo-shine-overlay::after {
+  content: '';
+  position: absolute;
+  inset: -60%;
+  background: conic-gradient(from 0deg,
+    #ff0080, #8b00ff, #0080ff, #00ffcc, #ffee00, #ff6a00, #ff0080);
+  mix-blend-mode: color-dodge;
+  opacity: 0.22;
+  animation: holoDrift 7s linear infinite;
 }
 
 .reverse-holo-shine-overlay {
   position: absolute;
   top: 0; left: 0; right: 0; bottom: 0;
-  background: linear-gradient(135deg,
-    rgba(255, 255, 255, 0.25) 0%,
-    rgba(255, 255, 255, 0) 30%,
-    rgba(255, 255, 255, 0.2) 50%,
-    rgba(255, 255, 255, 0) 70%,
-    rgba(255, 255, 255, 0.25) 100%
+  overflow: hidden;
+  border-radius: inherit;
+  background: repeating-linear-gradient(112deg,
+    rgba(220, 240, 255, 0.06) 0px,
+    rgba(220, 240, 255, 0.06) 6px,
+    rgba(0, 0, 0, 0) 6px,
+    rgba(0, 0, 0, 0) 13px
   );
-  background-size: 200% 200%;
   pointer-events: none;
   z-index: 5;
   mix-blend-mode: overlay;
-  opacity: 0.4;
+  opacity: 0.55;
   transition: opacity 0.3s ease, background-position 0.05s ease-out;
+}
+.reverse-holo-shine-overlay::after {
+  content: '';
+  position: absolute;
+  top: -20%; bottom: -20%;
+  left: 0;
+  width: 45%;
+  background: linear-gradient(90deg,
+    transparent,
+    rgba(190, 225, 255, 0.55) 45%,
+    rgba(255, 255, 255, 0.65) 50%,
+    rgba(190, 225, 255, 0.55) 55%,
+    transparent);
+  animation: foilSweep 4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .holo-shine-overlay::after,
+  .reverse-holo-shine-overlay::after { animation: none; }
 }
 
 /* 3D Card Hover Tilt Effects */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1421,6 +1421,18 @@ button, input, select, textarea {
   font-size: 0.7rem;
 }
 
+/* Smooth view transition when switching top-level tabs */
+@keyframes viewFadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.view-transition {
+  animation: viewFadeIn 0.28s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .view-transition { animation: none; }
+}
+
 /* ==========================================================================
    FOIL FINISHES — Holofoil vs Reverse Holofoil are intentionally distinct.
    Holofoil  = full rainbow prism that drifts continuously (screen blend).

--- a/frontend/src/utils/cardPrinting.js
+++ b/frontend/src/utils/cardPrinting.js
@@ -1,0 +1,47 @@
+// Single source of truth for how a card's printing/finish is displayed across
+// every view (Collection gallery/list, Storage visualizers, inspectors).
+//
+// Previously each view invented its own badge text ("HOLO" vs "Holo"), colors
+// (amber/blue vs amber/gray), and foil overlay treatment, so the same card
+// looked different depending on where you saw it. Everything now routes here.
+
+// Short uppercase badge label shown on card thumbnails.
+export function getPrintingBadgeLabel(printing) {
+  switch (printing) {
+    case 'Holofoil': return 'HOLO';
+    case 'Reverse Holofoil': return 'REV';
+    case '1st Edition': return '1ST';
+    case 'Promo': return 'PRM';
+    default: return '';
+  }
+}
+
+// Badge background/text colors. Holo and Reverse Holo are deliberately given
+// distinct hues (warm gold vs cool cyan) so they are legible at a glance and
+// never mistaken for each other.
+export function getPrintingBadgeStyle(printing) {
+  switch (printing) {
+    case 'Holofoil':
+      return { background: 'linear-gradient(135deg, #fbbf24, #f59e0b)', color: '#1a1206' };
+    case 'Reverse Holofoil':
+      return { background: 'linear-gradient(135deg, #67e8f9, #22d3ee)', color: '#05262b' };
+    case '1st Edition':
+      return { background: 'linear-gradient(135deg, #c4b5fd, #8b5cf6)', color: '#160a2e' };
+    case 'Promo':
+      return { background: 'linear-gradient(135deg, #fca5a5, #ef4444)', color: '#2a0606' };
+    default:
+      return { background: 'rgba(148, 163, 184, 0.85)', color: '#0a0f1d' };
+  }
+}
+
+// Returns the CSS class for the animated foil overlay, or null for finishes
+// that get no shine. Holofoil -> rainbow prism; Reverse Holofoil -> silver sweep.
+export function getFoilOverlayClass(printing) {
+  if (printing === 'Holofoil') return 'holo-shine-overlay';
+  if (printing === 'Reverse Holofoil') return 'reverse-holo-shine-overlay';
+  return null;
+}
+
+export function isFoil(printing) {
+  return printing === 'Holofoil' || printing === 'Reverse Holofoil';
+}

--- a/frontend/src/utils/containerSuggest.js
+++ b/frontend/src/utils/containerSuggest.js
@@ -1,0 +1,113 @@
+// Cross-location "best container" suggestion engine.
+//
+// Previously the sorting assistant could only recommend a slot WITHIN a
+// container the user had already picked, and the per-container `assignedSets`
+// config was written but never read by anything. This module fixes both: given
+// an unsorted card and every location (plus the full card list), it scores all
+// containers and returns a ranked recommendation with a human-readable reason.
+
+const BOX_TYPES = ['Box', 'Toploader Box', 'Graded Slab Box', 'Display Shelf / Stand'];
+const BINDER_TYPES = ['Binder', 'Toploader Binder'];
+
+function parseConfig(loc) {
+  if (!loc || !loc.description) return {};
+  try {
+    const d = loc.description.trim();
+    if (d.startsWith('{') && d.endsWith('}')) return JSON.parse(d);
+  } catch { /* not JSON config */ }
+  return {};
+}
+
+function pocketsFor(pageStyle) {
+  return pageStyle === '2x2' ? 4 : pageStyle === '3x4' ? 12 : 9;
+}
+
+// Physical capacity of a container (best-effort from its configured shape).
+export function capacityOf(loc) {
+  const cfg = parseConfig(loc);
+  if (BINDER_TYPES.includes(loc.type)) return (loc.max_pages || 30) * pocketsFor(loc.page_style);
+  if (BOX_TYPES.includes(loc.type)) return (loc.max_rows || 3) * (cfg.rowCapacity || 40);
+  if (loc.type === 'Deck Box') return cfg.targetDeckSize || 60;
+  return loc.max_capacity || 1000;
+}
+
+function primaryType(card) {
+  const t = card?.types;
+  if (Array.isArray(t)) return t[0];
+  if (typeof t === 'string') return t.split(',')[0]?.trim();
+  return undefined;
+}
+
+// Build per-location profiles (count, sets present, types present) from the
+// full card list in one pass, so scoring many cards stays cheap.
+export function buildLocationProfiles(allCards) {
+  const profiles = new Map();
+  const ensure = (id) => {
+    if (!profiles.has(id)) profiles.set(id, { count: 0, sets: new Set(), types: new Set() });
+    return profiles.get(id);
+  };
+  for (const c of allCards) {
+    if (!c.location_id) continue;
+    const p = ensure(c.location_id);
+    p.count += 1;
+    if (c.set_name) p.sets.add(c.set_name);
+    const pt = primaryType(c);
+    if (pt) p.types.add(pt);
+  }
+  return profiles;
+}
+
+// Score a single (card, location) pair. Higher is better; null means unusable.
+function scoreLocation(card, loc, profile) {
+  // Decks are hand-curated; never auto-route loose cards into them.
+  if (loc.type === 'Deck Box') return null;
+
+  const cfg = parseConfig(loc);
+  const count = profile?.count || 0;
+  const capacity = capacityOf(loc);
+  const free = capacity - count;
+  if (free <= 0) return null; // full — not a candidate
+
+  let score = 0;
+  const reasons = [];
+
+  const assigned = Array.isArray(cfg.assignedSets) ? cfg.assignedSets : [];
+  if (card.set_name && assigned.some((s) => s.toLowerCase() === card.set_name.toLowerCase())) {
+    score += 100;
+    reasons.push(`assigned to ${card.set_name}`);
+  } else if (card.set_name && profile?.sets.has(card.set_name)) {
+    score += 45;
+    reasons.push(`already holds ${card.set_name}`);
+  } else {
+    const pt = primaryType(card);
+    if (pt && profile?.types.has(pt)) {
+      score += 12;
+      reasons.push(`matches ${pt} cards here`);
+    }
+  }
+
+  // Gentle preference for containers with breathing room, and a small nudge
+  // toward binders for singles worth showing off vs. bulk boxes.
+  score += Math.min(free, 200) * 0.02;
+  if (BINDER_TYPES.includes(loc.type)) score += 1;
+
+  if (reasons.length === 0) reasons.push(`has ${free} free slot${free !== 1 ? 's' : ''}`);
+
+  return { score, reason: reasons[0], free, capacity };
+}
+
+// Returns ranked candidates: [{ location, score, reason, free, capacity }].
+export function suggestContainers(card, locations, profiles, { limit = 3 } = {}) {
+  if (!card || !Array.isArray(locations)) return [];
+  const scored = [];
+  for (const loc of locations) {
+    const res = scoreLocation(card, loc, profiles.get(loc.id));
+    if (res) scored.push({ location: loc, ...res });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit);
+}
+
+export function suggestBestContainer(card, locations, profiles) {
+  return suggestContainers(card, locations, profiles, { limit: 1 })[0] || null;
+}


### PR DESCRIPTION
Comprehensive cleanup pass. Work lands as incremental commits; this PR stays draft until all phases are in.

## Goals
- Unify how cards look between **Collection** and **Storage** (currently rendered by ~7 divergent code paths).
- Make **Holofoil vs Reverse Holofoil** visibly different.
- Remove unprofessional formatting (e.g. `(x3)` parentheses in storage).
- Fix the **cut-off price history** chart.
- Improve **Dashboard** and **Settings** content ("better things to list").
- Improve the **card storage + suggestion system** (cross-location recommendations, honor `assignedSets`).

## Phases
- [x] **0** — apply stashed box config (editable rows, cards-per-row capacity, assigned sets) + fix `rowCapacity` inconsistency
- [x] **1** — foil distinction (animated), shared `<PriceHistoryChart>`, shared printing badges, remove `(x3)` parens
- [ ] **2** — shared `<CardTile>` component; unify Collection + Storage rendering
- [ ] **3** — view transitions + typography polish
- [ ] **4** — price history in Storage inspector, loading skeletons, a11y
- [ ] **Dashboard** — replace vanity KPIs (Mint Rate/Vintage Ratio) with ROI / spend-vs-value, biggest movers, recent additions
- [ ] **Settings** — currency, default condition/printing, mask API key, copy polish, data reset
- [ ] **Suggestion system** — cross-location "best container" recommender using `assignedSets` + capacity
- [ ] **5** — split the 3.5k-line LocationManager into per-visualizer components

🤖 Generated with [Claude Code](https://claude.com/claude-code)