### PR TITLE
fix(price-history): make 1M/1Y/5Y chart windows actually differ

### DIFF
--- a/backend/src/routes/collection.js
+++ b/backend/src/routes/collection.js
@@ -1128,25 +1128,22 @@ router.get('/cards/:id/price-history', async (req, res) => {
         `, [id]);
 
     history = history.map(h => ({ price: h.price, recorded_at: h.recorded_at }));
+    const realCount = history.length;
 
     // Fill in with real anchor points instead of fabricating a curve: the
-    // current price, plus Cardmarket's real avg7/avg30 when they fall inside
-    // the requested window. This app's own price_history only goes back as
-    // far as it's actually been running, so this is often the only
-    // historical signal available for a given card right now. Prefer avg1 for
-    // "now" so all three anchors are the same marketplace (Cardmarket) —
-    // pairing avg7/avg30 with price_trend (usually TCGPlayer) would plot a
-    // jump that's really just the US/EU price gap, not a real move.
+    // current price, plus Cardmarket's real avg7/avg30. Only meaningful on
+    // the 1-month window — on a 1y/5y timeline, a point 7 or 30 days back
+    // sits right on top of "now" and previously got added for every range
+    // (the `days >= 7`/`days >= 30` guards were always true for all three
+    // defined ranges), which is why every window looked the same.
     const cacheCard = await db.get(`SELECT price_trend, price_avg1, price_avg7, price_avg30 FROM card_cache WHERE id = ?`, [id]);
     if (cacheCard) {
       const now = Date.now();
       const nowPrice = cacheCard.price_avg1 > 0 ? cacheCard.price_avg1 : cacheCard.price_trend;
       const anchors = [{ price: nowPrice, time: now }];
-      if (cacheCard.price_avg30 > 0 && (!days || days >= 30)) {
-        anchors.push({ price: cacheCard.price_avg30, time: now - 30 * 86400000 });
-      }
-      if (cacheCard.price_avg7 > 0 && (!days || days >= 7)) {
-        anchors.push({ price: cacheCard.price_avg7, time: now - 7 * 86400000 });
+      if (rangeKey === '1m') {
+        if (cacheCard.price_avg30 > 0) anchors.push({ price: cacheCard.price_avg30, time: now - 30 * 86400000 });
+        if (cacheCard.price_avg7 > 0) anchors.push({ price: cacheCard.price_avg7, time: now - 7 * 86400000 });
       }
       for (const a of anchors) {
         if (a.price > 0) {
@@ -1157,7 +1154,13 @@ router.get('/cards/:id/price-history', async (req, res) => {
 
     history.sort((a, b) => parseSqliteUtc(a.recorded_at) - parseSqliteUtc(b.recorded_at));
 
-    res.json(history);
+    // 1y/5y have no real historical price source beyond this app's own
+    // weekly-cadence price_history table (see Dashboard's change1y/5y, which
+    // is marked unavailable rather than faked for the same reason) — flag it
+    // instead of rendering a near-identical current-price-only line.
+    const insufficientHistory = (rangeKey === '1y' || rangeKey === '5y') && realCount < 2;
+
+    res.json({ data: history, insufficientHistory });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Failed to retrieve price history' });

--- a/frontend/src/components/PriceHistoryChart.jsx
+++ b/frontend/src/components/PriceHistoryChart.jsx
@@ -21,6 +21,7 @@ export default function PriceHistoryChart({
 }) {
   const [range, setRange] = useState(defaultRange);
   const [data, setData] = useState([]);
+  const [insufficientHistory, setInsufficientHistory] = useState(false);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -35,7 +36,10 @@ export default function PriceHistoryChart({
         const response = await fetch(`/api/cards/${cardId}/price-history?range=${range}`);
         if (response.ok) {
           const json = await response.json();
-          if (!cancelled) setData(json);
+          if (!cancelled) {
+            setData(json.data ?? []);
+            setInsufficientHistory(!!json.insufficientHistory);
+          }
         }
       } catch (err) {
         console.error('Error fetching price history:', err);
@@ -45,6 +49,11 @@ export default function PriceHistoryChart({
     })();
     return () => { cancelled = true; };
   }, [cardId, range]);
+
+  const chartData = useMemo(
+    () => (data || []).map(d => ({ ...d, ts: new Date(d.recorded_at).getTime() })),
+    [data]
+  );
 
   const { pctChange, absChange } = useMemo(() => {
     if (!data || data.length < 2) return { pctChange: null, absChange: null };
@@ -108,13 +117,17 @@ export default function PriceHistoryChart({
       <div style={{ width: '100%', height: `${height}px` }}>
         {loading ? (
           <div className="spinner" style={{ height: '30px', margin: `${Math.max(0, height / 2 - 15)}px auto` }} />
-        ) : (!data || data.length === 0) ? (
+        ) : insufficientHistory ? (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', fontSize: '0.75rem', color: 'var(--text-muted)', textAlign: 'center' }}>
+            Not enough price history yet for this range.
+          </div>
+        ) : (!chartData || chartData.length === 0) ? (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', fontSize: '0.75rem', color: 'var(--text-muted)' }}>
             No price data for this window.
           </div>
         ) : (
           <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <AreaChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
               <defs>
                 <linearGradient id="priceGlow" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="var(--accent-yellow)" stopOpacity={0.3} />
@@ -122,7 +135,7 @@ export default function PriceHistoryChart({
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
-              <XAxis dataKey="recorded_at" hide />
+              <XAxis dataKey="ts" type="number" scale="time" domain={['dataMin', 'dataMax']} hide />
               <YAxis
                 domain={['auto', 'auto']}
                 stroke="var(--text-secondary)"


### PR DESCRIPTION
## Summary
- Fixed dead conditional in `/api/cards/:id/price-history`: anchor-point gating (`days >= 30`/`days >= 7`) was true for every defined range (1m/1y/5y all satisfy `>=30`), so identical anchor points rendered for every window.
- avg7/avg30 anchors now only apply to the 1M window; 1Y/5Y return `insufficientHistory: true` when there are fewer than 2 real `price_history` rows, matching Dashboard's existing "not enough history" pattern instead of faking a flat curve.
- Frontend `PriceHistoryChart.jsx` now reads the new `{ data, insufficientHistory }` response shape, shows the "Not enough price history yet for this range" message when flagged, and uses a real numeric/time-scaled XAxis so point spacing reflects actual elapsed time instead of even-by-index spacing.

## Test plan
- [ ] `npm install` + run dev servers, open a card's price chart, toggle 1M/1Y/5Y and confirm the curves/messages differ
- [ ] Verify a card added recently shows "Not enough price history yet for this range" on 1Y/5Y
- [ ] Verify 1M still shows avg7/avg30 anchors alongside any real recent rows

Note: could not run the frontend dev server in this sandbox (no `node_modules` installed for `frontend/`); verified with `node --check` on the backend route and manual code review only.