### PR TITLE
feat(settings): admin-configurable public base URL for share links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@ POKEMON_TCG_API_KEY=
 # when deploying somewhere other than localhost.
 CORS_ORIGIN=http://localhost:5173,http://localhost:3001
 
+# Optional: the canonical externally-reachable URL for this instance, used to
+# build collection share links. Set this when running behind a reverse proxy
+# where the browser's own origin (protocol+host) isn't the address others
+# should use to reach your share links, e.g. https://cards.example.com
+# Can also be overridden later by an admin from the Admin Panel without
+# redeploying.
+PUBLIC_BASE_URL=
+
 # Optional: set a known password for the auto-created "admin" account on first
 # run. If unset, a random password is generated and printed once to the
 # server logs on first startup — check the logs to retrieve it.

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -93,6 +93,17 @@ async function initDb() {
     )
   `);
 
+  // Single-row instance-wide settings (currently just the public base URL
+  // used for collection share links behind a reverse proxy). id is pinned
+  // to 1 since there's only ever one row.
+  await run(`
+    CREATE TABLE IF NOT EXISTS app_settings (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      public_base_url TEXT DEFAULT ''
+    )
+  `);
+  await run(`INSERT OR IGNORE INTO app_settings (id, public_base_url) VALUES (1, '')`);
+
   // Create locations table
   await run(`
     CREATE TABLE IF NOT EXISTS locations (

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const db = require('../db');
+const { authenticateToken, requireAdmin } = require('../middleware/auth');
+
+const router = express.Router();
+
+async function getEffectiveSettings() {
+  const row = await db.get(`SELECT public_base_url FROM app_settings WHERE id = 1`);
+  const public_base_url = (row && row.public_base_url) || process.env.PUBLIC_BASE_URL || '';
+  return { public_base_url };
+}
+
+// Any logged-in user can read effective settings (needed to render share links)
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    res.json(await getEffectiveSettings());
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to retrieve settings' });
+  }
+});
+
+// Only admins can override settings
+router.put('/', authenticateToken, requireAdmin, async (req, res) => {
+  const { public_base_url } = req.body;
+
+  if (public_base_url !== undefined) {
+    const trimmed = public_base_url.trim();
+    if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+      return res.status(400).json({ error: 'Public base URL must start with http:// or https://' });
+    }
+    const cleaned = trimmed.replace(/\/+$/, '');
+    await db.run(`UPDATE app_settings SET public_base_url = ? WHERE id = 1`, [cleaned]);
+  }
+
+  try {
+    res.json(await getEffectiveSettings());
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to update settings' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ const sharedRoutes = require('./routes/shared');
 const adminRoutes = require('./routes/admin');
 const collectionRoutes = require('./routes/collection');
 const decksRoutes = require('./routes/decks');
+const settingsRoutes = require('./routes/settings');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -73,6 +74,7 @@ app.use('/api/shared', sharedRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api', collectionRoutes);
 app.use('/api/decks', decksRoutes);
+app.use('/api/settings', settingsRoutes);
 
 // Serve production static assets from Frontend
 const frontendBuildPath = path.join(__dirname, '../../frontend/dist');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - DB_PATH=/app/database/pokemon_cards.db
       - POKEMON_TCG_API_KEY= # Optional: Add your Pokemon TCG API Key here to increase rate limits
       - CORS_ORIGIN=http://localhost:3001 # Update if serving the frontend from a different origin
+      - PUBLIC_BASE_URL= # Optional: set the externally-reachable URL for share links when behind a reverse proxy, e.g. https://cards.example.com (also editable from the Admin Panel)
       - DEFAULT_ADMIN_PASSWORD= # Optional: pin the initial admin password instead of using the auto-generated one (see startup logs)
     volumes:
       - pokedexrr-data:/app/database

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Shield, UserPlus, Key, Trash2, ToggleLeft, ToggleRight, Search, Users } from 'lucide-react';
+import { Shield, UserPlus, Key, Trash2, ToggleLeft, ToggleRight, Search, Users, Globe } from 'lucide-react';
 
 function AdminPanel({ showToast }) {
   const [users, setUsers] = useState([]);
@@ -17,8 +17,13 @@ function AdminPanel({ showToast }) {
   const [updatePassword, setUpdatePassword] = useState('');
   const [pwdLoading, setPwdLoading] = useState(false);
 
+  // Instance Settings States
+  const [publicBaseUrl, setPublicBaseUrl] = useState('');
+  const [settingsLoading, setSettingsLoading] = useState(false);
+
   useEffect(() => {
     fetchUsers();
+    fetchSettings();
   }, []);
 
   const handleSeedDatabase = async () => {
@@ -55,6 +60,44 @@ function AdminPanel({ showToast }) {
       showToast('Error connecting to backend.');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchSettings = async () => {
+    try {
+      const response = await fetch('/api/settings');
+      if (response.ok) {
+        const data = await response.json();
+        setPublicBaseUrl(data.public_base_url || '');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSaveSettings = async (e) => {
+    e.preventDefault();
+    setSettingsLoading(true);
+    try {
+      const response = await fetch('/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ public_base_url: publicBaseUrl })
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setPublicBaseUrl(data.public_base_url || '');
+        showToast('Instance settings updated.');
+      } else {
+        const data = await response.json();
+        showToast(data.error || 'Failed to update settings.');
+      }
+    } catch (err) {
+      console.error(err);
+      showToast('Error updating settings.');
+    } finally {
+      setSettingsLoading(false);
     }
   };
 
@@ -263,6 +306,36 @@ function AdminPanel({ showToast }) {
             </div>
             <button type="submit" className="btn btn-primary" style={{ padding: '0.6rem', fontWeight: 700 }} disabled={addLoading}>
               {addLoading ? <div className="spinner" style={{ width: '14px', height: '14px', margin: 0, borderWidth: '2px' }}></div> : 'Create Account'}
+            </button>
+          </form>
+        </div>
+
+        {/* Instance Settings Panel */}
+        <div className="glass-panel" style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+          <h3 style={{ color: '#fff', fontSize: '1.1rem', borderBottom: '1px solid var(--border-glass)', paddingBottom: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Globe size={18} style={{ color: 'var(--accent-red)' }} />
+            Instance Settings
+          </h3>
+          <form onSubmit={handleSaveSettings} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <div style={{ background: 'rgba(255, 71, 71, 0.03)', border: '1px solid var(--border-glass)', padding: '0.75rem 1rem', borderRadius: 'var(--radius-sm)', fontSize: '0.8rem', color: 'var(--text-secondary)', lineHeight: '1.4' }}>
+              If this app runs behind a reverse proxy, the browser's own address may not be the one others should use to reach a collection share link. Set the public URL here to override it. Leave blank to use the browser's address (or the <code>PUBLIC_BASE_URL</code> environment variable, if set).
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label htmlFor="admin-public-base-url">Public Base URL</label>
+              <input
+                id="admin-public-base-url"
+                type="text"
+                name="public-base-url"
+                autoComplete="off"
+                className="input-control"
+                placeholder="https://cards.example.com"
+                value={publicBaseUrl}
+                onChange={(e) => setPublicBaseUrl(e.target.value)}
+                disabled={settingsLoading}
+              />
+            </div>
+            <button type="submit" className="btn btn-primary" style={{ padding: '0.6rem', fontWeight: 700, alignSelf: 'flex-start' }} disabled={settingsLoading}>
+              {settingsLoading ? <div className="spinner" style={{ width: '14px', height: '14px', margin: 0, borderWidth: '2px' }}></div> : 'Save Settings'}
             </button>
           </form>
         </div>

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -14,6 +14,17 @@ function Settings({ user, onUpdateUser, showToast }) {
   const [tcgApiKey, setTcgApiKey] = useState(user?.tcg_api_key || '');
   const [apiKeyLoading, setApiKeyLoading] = useState(false);
 
+  const [publicBaseUrl, setPublicBaseUrl] = useState('');
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data) setPublicBaseUrl(data.public_base_url || '');
+      })
+      .catch(() => {});
+  }, []);
+
   const handleImportFile = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -210,9 +221,10 @@ function Settings({ user, onUpdateUser, showToast }) {
     }
   };
 
-  const shareUrl = `${window.location.protocol}//${window.location.host}/share/${user?.share_token}`;
-  const tradeUrl = `${window.location.protocol}//${window.location.host}/share/${user?.share_token}?list=trade`;
-  const wishlistUrl = `${window.location.protocol}//${window.location.host}/share/${user?.share_token}?list=wishlist`;
+  const origin = publicBaseUrl || `${window.location.protocol}//${window.location.host}`;
+  const shareUrl = `${origin}/share/${user?.share_token}`;
+  const tradeUrl = `${origin}/share/${user?.share_token}?list=trade`;
+  const wishlistUrl = `${origin}/share/${user?.share_token}?list=wishlist`;
 
   const [copiedType, setCopiedType] = useState(''); // 'collection', 'trade', 'wishlist'
 


### PR DESCRIPTION
## Summary
- Collection share links (`Settings.jsx`) were built from `window.location`, which points to the wrong address when the app runs behind a reverse proxy.
- Adds `PUBLIC_BASE_URL` env var (documented in `.env.example`/`docker-compose.yml`) as a default, and an admin-only DB override editable from the Admin Panel that takes precedence — no redeploy needed to change it.
- New `GET/PUT /api/settings`: any logged-in user can read the effective URL, only admins can set it. Rejects values not starting with `http://`/`https://`.

## Test plan
- [x] `node -c` syntax check on all touched backend files
- [x] Started server locally, logged in as admin: `GET /api/settings` returns `""` with nothing configured
- [x] `PUT` with invalid URL (`not-a-url`) → 400
- [x] `PUT` with valid URL → stored, trailing slash stripped, persists across `GET`
- [x] Non-admin member: `GET` succeeds, `PUT` → 403
- [ ] Manual check of the Admin Panel UI and Settings page share-link rendering in a browser

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>