### PR TITLE
fix(printing): game-aware foil options so MTG cards can be set to Foil

### DIFF
--- a/frontend/src/components/CameraScanner.jsx
+++ b/frontend/src/components/CameraScanner.jsx
@@ -4,7 +4,7 @@ import confetti from 'canvas-confetti';
 import { getCardDisplayName } from '../utils/langHelper';
 import { formatPrice } from '../utils/formatPrice';
 import { resolveCardPrice } from '../utils/resolveCardPrice';
-import { CONDITIONS, PRINTINGS } from '../utils/cardOptions';
+import { CONDITIONS, getPrintings } from '../utils/cardOptions';
 import CardEntryFields from './CardEntryFields';
 import PackPriceSplitter from './PackPriceSplitter';
 // Fixed centered guide box (normalized 0..1). Center the card in it; the crop
@@ -1221,7 +1221,7 @@ function CameraScanner({ onAddSuccess, showToast, setActiveTab }) {
                   <div className="form-group" style={{ marginBottom: 0, flex: 1, textAlign: 'left' }}>
                     <label>Printing</label>
                     <select className="select-control" value={autoAddPrint} onChange={(e) => setAutoAddPrint(e.target.value)}>
-                      {PRINTINGS.map(p => <option key={p} value={p}>{p}</option>)}
+                      {getPrintings(autoAddTargetCard.game || autoAddTargetCard.supertype).map(p => <option key={p.value} value={p.value}>{p.label}</option>)}
                     </select>
                   </div>
                 </div>
@@ -1603,6 +1603,7 @@ function CameraScanner({ onAddSuccess, showToast, setActiveTab }) {
                   
                   <CardEntryFields
                     variant="stacked"
+                    game={selectedCard.game || selectedCard.supertype}
                     quantity={quantity} purchasePrice={purchasePrice} condition={condition} printing={printing} language={language}
                     onQuantity={setQuantity} onPurchasePrice={setPurchasePrice} onCondition={setCondition} onPrinting={setPrinting} onLanguage={setLanguage}
                   />

--- a/frontend/src/components/CardEntryFields.jsx
+++ b/frontend/src/components/CardEntryFields.jsx
@@ -1,4 +1,4 @@
-import { CONDITIONS, PRINTINGS, LANGUAGES } from '../utils/cardOptions';
+import { CONDITIONS, getPrintings, LANGUAGES } from '../utils/cardOptions';
 
 // Shared quantity / purchase-price / condition / printing / language inputs for
 // the add-card and edit-card flows. Presentational only: the parent owns the
@@ -10,9 +10,10 @@ import { CONDITIONS, PRINTINGS, LANGUAGES } from '../utils/cardOptions';
 export default function CardEntryFields({
   quantity, purchasePrice, condition, printing, language,
   onQuantity, onPurchasePrice, onCondition, onPrinting, onLanguage,
-  variant = 'grid',
+  variant = 'grid', game,
 }) {
   const stacked = variant === 'stacked';
+  const printings = getPrintings(game);
   const groupStyle = stacked ? { marginBottom: 0 } : undefined;
 
   const stepQty = (delta) => onQuantity(String(Math.max(1, (parseInt(quantity, 10) || 1) + delta)));
@@ -51,7 +52,7 @@ export default function CardEntryFields({
     <div className="form-group" style={groupStyle}>
       <label>Printing</label>
       <select className="select-control" value={printing} onChange={(e) => onPrinting(e.target.value)}>
-        {PRINTINGS.map(p => <option key={p} value={p}>{p}</option>)}
+        {printings.map(p => <option key={p.value} value={p.value}>{p.label}</option>)}
       </select>
     </div>
   );

--- a/frontend/src/components/CardInspectorModal.jsx
+++ b/frontend/src/components/CardInspectorModal.jsx
@@ -275,6 +275,7 @@ function CardInspectorModal({ card, onClose, onUpdate, showToast, onViewStorage,
               )}
 
               <CardEntryFields
+                game={card.game || card.supertype}
                 quantity={q} purchasePrice={purchasePrice} condition={condition} printing={printing} language={language}
                 onQuantity={setQ} onPurchasePrice={setPurchasePrice} onCondition={setCondition} onPrinting={setPrinting} onLanguage={setLanguage}
               />

--- a/frontend/src/utils/cardOptions.js
+++ b/frontend/src/utils/cardOptions.js
@@ -5,6 +5,18 @@ export const CONDITIONS = ['Near Mint', 'Lightly Played', 'Moderately Played', '
 export const PRINTINGS = ['Normal', 'Holofoil', 'Reverse Holofoil', '1st Edition', 'Promo'];
 export const LANGUAGES = ['English', 'Japanese', 'German', 'French', 'Spanish', 'Italian'];
 
+// MTG cards are only Nonfoil or Foil, never the Pokémon finishes. The foil
+// price is stored under the 'Holofoil' value (scryfall usd_foil), so we keep
+// that stored value (also what the DB CHECK allows) and just relabel it "Foil".
+const MTG_PRINTINGS = [{ value: 'Normal', label: 'Nonfoil' }, { value: 'Holofoil', label: 'Foil' }];
+
+// Printing/finish {value,label} options for a card's game. Value stays within
+// the collection.printing CHECK constraint; only the label is game-specific.
+export function getPrintings(game) {
+  if (String(game).toLowerCase() === 'mtg') return MTG_PRINTINGS;
+  return PRINTINGS.map(p => ({ value: p, label: p }));
+}
+
 // A binder-family container lays out fixed pockets (Pages); other container
 // types (boxes, deck boxes) are continuous (Rows). Kept here so the several
 // UI spots that branch on it share one definition.


### PR DESCRIPTION
## What

The **Printing** dropdown in the edit card menu (and scanner quick-add / auto-add foil editor) was game-blind. It only offered Pokémon finishes — Normal, Holofoil, Reverse Holofoil, 1st Edition, Promo. For an all-MTG collection there was no **Foil** option, so MTG cards could not be marked foil. Reported as "can't change the foil type in the edit card menu."

## Why it works

MTG foil price is already stored under the `Holofoil` value (scryfall `usd_foil`, mapped in `scryfallApi.js`). So relabeling is enough:

- New `getPrintings(game)` helper in `cardOptions.js`
  - MTG → `Nonfoil` / `Foil` (Foil stores value `Holofoil`)
  - Pokémon → existing 5 finishes, unchanged
- `CardEntryFields` takes a `game` prop and renders `{value,label}` options
- `CardInspectorModal` passes `card.game || card.supertype`
- `CameraScanner` quick-add + auto-add foil editor pass game too

No DB migration: `Holofoil` is already allowed by the `collection.printing` CHECK constraint, and `resolveCardPrice` already maps `Holofoil` → `price_holofoil` (= MTG `usd_foil`).

## Verified

Reproduced and fixed in the running app: MTG edit menu now shows Nonfoil/Foil; selecting Foil persists (`printing=Holofoil`) with the foil price applied. Backend PUT path confirmed independently.

## Not included (out of scope)

- Bulk-edit printing dropdown (CollectionList) and shared-collection filter still show the full Pokémon list — they operate over mixed/no-game selections.
- MTG foil cards still render a "HOLO" thumbnail badge rather than "FOIL".

🤖 Generated with [Claude Code](https://claude.com/claude-code)