### PR TITLE
Add Set Browser modal, fix tab-switch crash, and improve set-index management

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -323,6 +323,26 @@ router.delete('/set-indexes/:game/:set', (req, res) => {
   res.json({ message: `Removed ${game} ${set} index` });
 });
 
+// Browse sets for the set-index builder modal — returns all known sets with
+// symbol/logo images for the chosen game, newest releases first.
+router.get('/sets-browse', async (req, res) => {
+  const { game } = req.query;
+  if (!isGame(game)) return res.status(400).json({ error: 'game (mtg|pokemon) is required' });
+  try {
+    // Some older rows may have NULL game (defaults to 'pokemon').
+    const sets = await db.all(
+      `SELECT id, name, series, printed_total, release_date, symbol_url, logo_url
+       FROM sets WHERE game = ?1 OR (game IS NULL AND ?2 = 'pokemon')
+       ORDER BY release_date DESC`,
+      [game, game]
+    );
+    res.json(sets);
+  } catch (error) {
+    console.error('Error browsing sets:', error);
+    res.status(500).json({ error: 'Failed to retrieve sets' });
+  }
+});
+
 // --- Global scan index build management ---
 
 // On-disk status of the whole-game CLIP+ORB indexes plus any in-flight build.

--- a/backend/src/tcgApi.js
+++ b/backend/src/tcgApi.js
@@ -86,9 +86,9 @@ function extractDetailedPrices(card) {
 // without a restart (INSERT OR REPLACE below upserts, so this is idempotent).
 async function fetchAndCacheSets(force = false) {
   try {
-    const existingSets = await db.get('SELECT COUNT(*) as count FROM sets');
+    const existingSets = await db.get(`SELECT COUNT(*) as count FROM sets WHERE game = 'pokemon' OR game IS NULL`);
     if (!force && existingSets && existingSets.count > 0) {
-      console.log(`Sets table already populated (${existingSets.count} sets). Skipping fetch.`);
+      console.log(`Pokemon sets already populated (${existingSets.count} sets). Skipping fetch.`);
       return;
     }
 
@@ -108,12 +108,12 @@ async function fetchAndCacheSets(force = false) {
       }
     }
     
-    console.log(`Fetched ${sets.length} sets. Saving to database...`);
+    console.log(`Fetched ${sets.length} Pokemon sets. Saving to database...`);
     
     for (const s of sets) {
       await db.run(
-        `INSERT OR REPLACE INTO sets (id, name, series, printed_total, total, release_date, ptcgo_code, symbol_url, logo_url)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT OR REPLACE INTO sets (id, name, series, printed_total, total, release_date, ptcgo_code, symbol_url, logo_url, game)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pokemon')`,
         [
           s.id,
           s.name,
@@ -127,9 +127,12 @@ async function fetchAndCacheSets(force = false) {
         ]
       );
     }
-    console.log('Sets successfully cached.');
+    console.log(`Cached ${sets.length} Pokemon sets.`);
   } catch (error) {
-    console.error('Error fetching sets:', error.message);
+    const detail = error.response
+      ? `HTTP ${error.response.status}${error.response.data ? ': ' + JSON.stringify(error.response.data).slice(0, 200) : ''}`
+      : error.message;
+    console.error('Error fetching Pokemon sets:', detail);
   }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -97,14 +97,12 @@ function App() {
 
   // Navigate tabs through here so each change pushes a history entry: a back
   // gesture then returns to the PREVIOUS tab (not always dashboard), and modals
-  // stack their own guards on top. At the dashboard root with nothing pushed,
-  // back exits normally.
+  // stack their own guards on top. We never dispose the old tab guard — each
+  // switch pushes a fresh entry so the back button walks through tab history.
+  // Disposing with history.back() would race during rapid switches and navigate
+  // the browser past the app origin into about:blank.
   const goTab = (tab) => {
     if (tab === activeTab) return;
-    if (tabGuardRef.current) {
-      tabGuardRef.current();
-      tabGuardRef.current = null;
-    }
     const prev = activeTab;
     tabGuardRef.current = pushBackGuard(() => {
       tabGuardRef.current = null;

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
-import { Shield, UserPlus, Key, Trash2, ToggleLeft, ToggleRight, Search, Users, Globe, Database, Play, RefreshCw, AlertTriangle, HardDriveDownload, Download } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { Shield, UserPlus, Key, Trash2, ToggleLeft, ToggleRight, Search, Users, Globe, Database, Play, RefreshCw, AlertTriangle, HardDriveDownload, Download, BookOpen, ChevronDown, ChevronRight } from 'lucide-react';
 import { useBackGuard } from '../utils/useBackGuard';
+import SetBrowserModal from './SetBrowserModal';
 
 const formatBytes = (n) => {
   if (!n) return '0 B';
@@ -35,11 +36,16 @@ function AdminPanel({ showToast }) {
   // Set-index build states
   const [builds, setBuilds] = useState([]);
   const [buildProgress, setBuildProgress] = useState({});
-  const [buildGame, setBuildGame] = useState('mtg');
+  const [buildGame, setBuildGame] = useState(() => localStorage.getItem('default_game') || 'mtg');
   const [buildSetCode, setBuildSetCode] = useState('');
   const [preview, setPreview] = useState(null);
   const [previewLoading, setPreviewLoading] = useState(false);
+  const [showSetBrowser, setShowSetBrowser] = useState(false);
+  useBackGuard(showSetBrowser, () => setShowSetBrowser(false));
+  const [setNameMap, setSetNameMap] = useState({});
+  const [expandedGames, setExpandedGames] = useState(new Set(['mtg', 'pokemon']));
   const pollRef = useRef(null);
+  const mountedRef = useRef(true);
 
   // Global scan index states
   const [globals, setGlobals] = useState([]);
@@ -50,13 +56,44 @@ function AdminPanel({ showToast }) {
   const [backupLoading, setBackupLoading] = useState(false);
 
   useEffect(() => {
+    mountedRef.current = true;
     fetchUsers();
     fetchSettings();
     fetchBackups();
     Promise.all([fetchBuilds(), fetchGlobals()]).then(([a, b]) => { if (a || b) startPolling(); });
-    return stopPolling;
+    fetchSetNames();
+    return () => {
+      mountedRef.current = false;
+      stopPolling();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Build a lookup map: "game|setCode" → set name. MTG set ids are prefixed
+  // "mtg-" in the sets table (e.g. "mtg-mh3") but the build keys use the bare
+  // code ("mh3"), so we strip the prefix when building the lookup.
+  const fetchSetNames = async () => {
+    try {
+      const res = await fetch('/api/sets');
+      if (!res.ok) return;
+      const allSets = await res.json();
+      if (!mountedRef.current) return;
+      const map = {};
+      for (const s of allSets) {
+        const code = s.game === 'mtg' && s.id.startsWith('mtg-') ? s.id.slice(4) : s.id;
+        map[`${s.game}|${code}`] = s.name;
+      }
+      setSetNameMap(map);
+    } catch { /* non-critical */ }
+  };
+
+  const toggleGameExpand = (game) => {
+    setExpandedGames(prev => {
+      const next = new Set(prev);
+      if (next.has(game)) next.delete(game); else next.add(game);
+      return next;
+    });
+  };
 
   const stopPolling = () => {
     if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
@@ -75,6 +112,7 @@ function AdminPanel({ showToast }) {
       const res = await fetch('/api/admin/global-indexes');
       if (!res.ok) return false;
       const data = await res.json();
+      if (!mountedRef.current) return false;
       setGlobals(data.games || []);
       setGlobalProgress(data.progress || {});
       return Object.values(data.progress || {}).some(isGlobalActive);
@@ -120,6 +158,7 @@ function AdminPanel({ showToast }) {
       const res = await fetch('/api/admin/set-indexes');
       if (!res.ok) return false;
       const data = await res.json();
+      if (!mountedRef.current) return false;
       setBuilds(data.builds || []);
       setBuildProgress(data.progress || {});
       return Object.values(data.progress || {}).some(isActive);
@@ -174,6 +213,30 @@ function AdminPanel({ showToast }) {
     }
   };
 
+  // Silent build — no confirm dialog, doesn't close preview/manual input.
+  // Used by the Set Browser modal so users can queue multiple sets quickly.
+  const handleBuildSilent = async (game, set) => {
+    try {
+      const res = await fetch('/api/admin/set-indexes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ game, set }),
+      });
+      const data = await res.json();
+      if (!mountedRef.current) return;
+      if (res.ok) {
+        showToast(data.message);
+        await fetchBuilds();
+        startPolling();
+      } else {
+        showToast(data.error || 'Failed to start build.');
+      }
+    } catch (err) {
+      console.error(err);
+      showToast('Error starting build.');
+    }
+  };
+
   const handleDeleteBuild = async (game, set) => {
     if (!window.confirm(`Remove the ${game} "${set}" index? Scanning this set will rebuild it on demand.`)) return;
     try {
@@ -211,6 +274,7 @@ function AdminPanel({ showToast }) {
       const res = await fetch('/api/admin/backups');
       if (res.ok) {
         const data = await res.json();
+        if (!mountedRef.current) return;
         setBackups(data.backups || []);
       }
     } catch (err) {
@@ -262,6 +326,7 @@ function AdminPanel({ showToast }) {
       const response = await fetch('/api/admin/users');
       if (response.ok) {
         const data = await response.json();
+        if (!mountedRef.current) return;
         setUsers(data);
       } else {
         showToast('Failed to fetch user list.');
@@ -270,7 +335,7 @@ function AdminPanel({ showToast }) {
       console.error(err);
       showToast('Error connecting to backend.');
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   };
 
@@ -279,6 +344,7 @@ function AdminPanel({ showToast }) {
       const response = await fetch('/api/settings');
       if (response.ok) {
         const data = await response.json();
+        if (!mountedRef.current) return;
         setPublicBaseUrl(data.public_base_url || '');
       }
     } catch (err) {
@@ -584,6 +650,9 @@ function AdminPanel({ showToast }) {
             <button type="button" className="btn btn-secondary" style={{ height: '42px' }} onClick={handlePreview} disabled={previewLoading || !buildSetCode.trim()}>
               {previewLoading ? <div className="spinner" style={{ width: '14px', height: '14px', margin: 0, borderWidth: '2px' }}></div> : 'Preview'}
             </button>
+            <button type="button" className="btn btn-secondary" style={{ height: '42px', display: 'flex', alignItems: 'center', gap: '0.35rem' }} onClick={() => setShowSetBrowser(true)}>
+              <BookOpen size={14} /> Browse Sets
+            </button>
           </div>
 
           {preview && (
@@ -607,8 +676,9 @@ function AdminPanel({ showToast }) {
               <table className="collection-table">
                 <thead>
                   <tr>
-                    <th>Game</th>
+                    <th style={{ width: '28px' }}></th>
                     <th>Set</th>
+                    <th>Name</th>
                     <th>Cards</th>
                     <th>Size</th>
                     <th>Status</th>
@@ -621,53 +691,89 @@ function AdminPanel({ showToast }) {
                     const pending = Object.entries(buildProgress)
                       .filter(([key, p]) => isActive(p) && !builtKeys.has(key))
                       .map(([key]) => ({ key, game: key.split('|')[0], set: key.split('|')[1], cardCount: 0, sizeBytes: 0, builtAt: 0 }));
-                    return [...pending, ...builds].map((b) => {
-                      const p = buildProgress[b.key];
-                      const active = isActive(p);
-                      const pct = p && p.total ? Math.round((p.done / p.total) * 100) : 0;
+                    const all = [...pending, ...builds];
+
+                    // Group by game, sorted alphabetically
+                    const GAMES = ['mtg', 'pokemon'];
+                    return GAMES.map(g => {
+                      const group = all.filter(b => b.game === g);
+                      if (group.length === 0) return null;
+                      const expanded = expandedGames.has(g);
+                      const totalCards = group.reduce((sum, b) => sum + (b.cardCount || 0), 0);
+                      const totalSize = group.reduce((sum, b) => sum + (b.sizeBytes || 0), 0);
                       return (
-                        <tr key={b.key}>
-                          <td style={{ textTransform: 'uppercase', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>{b.game}</td>
-                          <td style={{ fontWeight: 700, color: 'var(--text-strong)' }}>{b.set}</td>
-                          <td>{b.cardCount || (p && p.total) || '-'}</td>
-                          <td style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{b.sizeBytes ? formatBytes(b.sizeBytes) : '-'}</td>
-                          <td style={{ minWidth: '160px' }}>
-                            {active ? (
-                              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                                <div style={{ height: '6px', background: 'rgba(255,255,255,0.08)', borderRadius: '3px', overflow: 'hidden' }}>
-                                  <div style={{ height: '100%', width: p.status === 'fetching' ? '15%' : `${pct}%`, background: 'var(--accent-red)', transition: 'width 0.4s ease' }}></div>
-                                </div>
-                                <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
-                                  {p.status === 'fetching' ? 'Fetching card list...' : `Indexing ${p.done}/${p.total} (${pct}%)`}
-                                </span>
-                              </div>
-                            ) : p && p.status === 'error' ? (
-                              <span style={{ fontSize: '0.75rem', color: 'var(--accent-red)' }} title={p.error}>Failed</span>
-                            ) : (
-                              <span style={{ fontSize: '0.75rem', color: 'var(--accent-green, #4ade80)' }}>Ready</span>
-                            )}
-                          </td>
-                          <td>
-                            <div style={{ display: 'flex', gap: '0.35rem' }}>
-                              <button
-                                className="btn btn-secondary btn-icon-only"
-                                title="Rebuild"
-                                onClick={() => handleBuild(b.game, b.set, 0)}
-                                disabled={active}
-                              >
-                                <RefreshCw size={14} />
-                              </button>
-                              <button
-                                className="btn btn-danger btn-icon-only"
-                                title="Remove index"
-                                onClick={() => handleDeleteBuild(b.game, b.set)}
-                                disabled={active}
-                              >
-                                <Trash2 size={14} />
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
+                        <React.Fragment key={g}>
+                          {/* Game header row */}
+                          <tr
+                            style={{ cursor: 'pointer', background: 'rgba(255,255,255,0.03)' }}
+                            onClick={() => toggleGameExpand(g)}
+                          >
+                            <td style={{ padding: '0.35rem 0.5rem' }}>
+                              {expanded ? <ChevronDown size={14} style={{ color: 'var(--text-muted)' }} /> : <ChevronRight size={14} style={{ color: 'var(--text-muted)' }} />}
+                            </td>
+                            <td colSpan={2} style={{ fontWeight: 700, textTransform: 'uppercase', fontSize: '0.8rem', color: 'var(--text-strong)' }}>
+                              {g === 'mtg' ? 'Magic: The Gathering' : 'Pokémon'}
+                              <span style={{ marginLeft: '0.5rem', fontWeight: 400, fontSize: '0.7rem', color: 'var(--text-muted)' }}>
+                                ({group.length} {group.length === 1 ? 'set' : 'sets'})
+                              </span>
+                            </td>
+                            <td style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>{totalCards || '-'}</td>
+                            <td style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>{totalSize ? formatBytes(totalSize) : '-'}</td>
+                            <td colSpan={2}></td>
+                          </tr>
+                          {/* Detail rows */}
+                          {expanded && group.map((b) => {
+                            const p = buildProgress[b.key];
+                            const active = isActive(p);
+                            const pct = p && p.total ? Math.round((p.done / p.total) * 100) : 0;
+                            const setName = setNameMap[b.key] || '';
+                            return (
+                              <tr key={b.key}>
+                                <td></td>
+                                <td style={{ fontWeight: 700, color: 'var(--text-strong)', fontFamily: 'monospace', fontSize: '0.8rem' }}>{b.set}</td>
+                                <td style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', maxWidth: '180px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={setName}>{setName || '-'}</td>
+                                <td>{b.cardCount || (p && p.total) || '-'}</td>
+                                <td style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{b.sizeBytes ? formatBytes(b.sizeBytes) : '-'}</td>
+                                <td style={{ minWidth: '160px' }}>
+                                  {active ? (
+                                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                                      <div style={{ height: '6px', background: 'rgba(255,255,255,0.08)', borderRadius: '3px', overflow: 'hidden' }}>
+                                        <div style={{ height: '100%', width: p.status === 'fetching' ? '15%' : `${pct}%`, background: 'var(--accent-red)', transition: 'width 0.4s ease' }}></div>
+                                      </div>
+                                      <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
+                                        {p.status === 'fetching' ? 'Fetching card list...' : `Indexing ${p.done}/${p.total} (${pct}%)`}
+                                      </span>
+                                    </div>
+                                  ) : p && p.status === 'error' ? (
+                                    <span style={{ fontSize: '0.75rem', color: 'var(--accent-red)' }} title={p.error}>Failed</span>
+                                  ) : (
+                                    <span style={{ fontSize: '0.75rem', color: 'var(--accent-green, #4ade80)' }}>Ready</span>
+                                  )}
+                                </td>
+                                <td>
+                                  <div style={{ display: 'flex', gap: '0.35rem' }}>
+                                    <button
+                                      className="btn btn-secondary btn-icon-only"
+                                      title="Rebuild"
+                                      onClick={() => handleBuild(b.game, b.set, 0)}
+                                      disabled={active}
+                                    >
+                                      <RefreshCw size={14} />
+                                    </button>
+                                    <button
+                                      className="btn btn-danger btn-icon-only"
+                                      title="Remove index"
+                                      onClick={() => handleDeleteBuild(b.game, b.set)}
+                                      disabled={active}
+                                    >
+                                      <Trash2 size={14} />
+                                    </button>
+                                  </div>
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </React.Fragment>
                       );
                     });
                   })()}
@@ -956,6 +1062,17 @@ function AdminPanel({ showToast }) {
             </form>
           </div>
         </div>
+      )}
+
+      {/* Set Browser Modal */}
+      {showSetBrowser && (
+        <SetBrowserModal
+          game={buildGame}
+          onClose={() => setShowSetBrowser(false)}
+          onStartBuild={handleBuildSilent}
+          existingKeys={builds.map(b => b.key)}
+          progress={buildProgress}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/SetBrowserModal.jsx
+++ b/frontend/src/components/SetBrowserModal.jsx
@@ -1,0 +1,239 @@
+import { useState, useEffect, useCallback } from 'react';
+import { X, Search, Database, Play, CheckCircle2, Zap } from 'lucide-react';
+import { useBackGuard } from '../utils/useBackGuard';
+
+function formatDate(d) {
+  if (!d) return '-';
+  try {
+    const date = new Date(d);
+    if (isNaN(date.getTime())) return d;
+    return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch { return d; }
+}
+
+/**
+ * Returns the bare set code for the build API (strips "mtg-" prefix for MTG sets).
+ */
+function bareSetCode(id, game) {
+  if (game === 'mtg' && id.startsWith('mtg-')) return id.slice(4);
+  return id;
+}
+
+const isActive = (p) => p && (p.status === 'fetching' || p.status === 'indexing');
+
+export default function SetBrowserModal({ game: initialGame, onClose, onStartBuild, existingKeys, progress }) {
+  const [game, setGame] = useState(initialGame || 'mtg');
+  const [sets, setSets] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('');
+  const [error, setError] = useState(null);
+  const [buildingSet, setBuildingSet] = useState(new Set());
+
+  useBackGuard(true, onClose);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchSets = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/admin/sets-browse?game=${game}`);
+        if (!res.ok) {
+          const d = await res.json().catch(() => ({}));
+          throw new Error(d.error || `HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        if (!cancelled) setSets(data);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchSets();
+    return () => { cancelled = true; };
+  }, [game]);
+
+  const existingSet = new Set(existingKeys || []);
+
+  const handleIndex = useCallback(async (g, setCode) => {
+    const key = `${g}|${setCode}`;
+    setBuildingSet(prev => new Set(prev).add(key));
+    try {
+      await onStartBuild(g, setCode);
+    } catch {
+      // onStartBuild handles its own errors/toasts
+    }
+    // Don't remove from buildingSet — the polling-driven existingKeys
+    // will cause the row to flip to "Indexed" once the build completes.
+  }, [onStartBuild]);
+
+  const handleIndexAll = () => {
+    const unbuilt = sets.filter(s => {
+      const code = bareSetCode(s.id, game);
+      const key = `${game}|${code}`;
+      return !existingSet.has(key) && !buildingSet.has(key) && !isActive(progress[key]);
+    });
+    if (unbuilt.length === 0) return;
+    if (!window.confirm(`Index all ${unbuilt.length} unbuilt ${game === 'mtg' ? 'MTG' : 'Pokémon'} sets? This downloads every card image for each set and can take a long time.`)) return;
+    for (const s of unbuilt) {
+      handleIndex(game, bareSetCode(s.id, game));
+    }
+  };
+
+  const filtered = filter.trim()
+    ? sets.filter(s => s.name.toLowerCase().includes(filter.toLowerCase()) || s.id.toLowerCase().includes(filter.toLowerCase()))
+    : sets;
+
+  const logoFor = (s) => s.logo_url || s.symbol_url || null;
+
+  const unbuiltCount = sets.filter(s => {
+    const code = bareSetCode(s.id, game);
+    return !existingSet.has(`${game}|${code}`);
+  }).length;
+
+  return (
+    <div
+      className="modal-overlay"
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onClick={onClose}
+    >
+      <div
+        style={{ width: '960px', maxWidth: '98vw', maxHeight: '90vh', overflowY: 'auto', padding: '1.25rem', display: 'flex', flexDirection: 'column', gap: '1rem', background: 'var(--bg-primary, #121212)', borderRadius: 'var(--radius-lg, 12px)', border: '1px solid var(--border-glass)', boxShadow: '0 8px 32px rgba(0,0,0,0.5)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h3 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Database size={18} style={{ color: 'var(--accent-red)' }} />
+            Browse Sets
+          </h3>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            {unbuiltCount > 0 && (
+              <button
+                type="button"
+                className="btn btn-primary"
+                style={{ padding: '0.35rem 0.75rem', fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: '0.35rem' }}
+                onClick={handleIndexAll}
+              >
+                <Zap size={14} /> Index All ({unbuiltCount})
+              </button>
+            )}
+            <button className="btn btn-secondary btn-icon-only" onClick={onClose} style={{ width: '28px', height: '28px', padding: 0 }}>
+              <X size={15} />
+            </button>
+          </div>
+        </div>
+
+        {/* Game selector + search */}
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: '0.35rem' }}>
+            {['mtg', 'pokemon'].map(g => (
+              <button
+                key={g}
+                type="button"
+                className={`btn ${game === g ? 'btn-primary' : 'btn-secondary'}`}
+                style={{ padding: '0.35rem 0.75rem', fontSize: '0.8rem' }}
+                onClick={() => setGame(g)}
+              >
+                {g === 'mtg' ? 'MTG' : 'Pokémon'}
+              </button>
+            ))}
+          </div>
+          <div className="form-group" style={{ marginBottom: 0, flex: 1, minWidth: '180px' }}>
+            <div style={{ position: 'relative' }}>
+              <Search size={14} style={{ position: 'absolute', left: '0.6rem', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
+              <input
+                type="text"
+                className="input-control"
+                placeholder="Filter sets..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                style={{ paddingLeft: '1.8rem' }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div style={{ padding: '2rem', textAlign: 'center' }}>
+            <div className="spinner" style={{ margin: '0 auto 0.5rem' }}></div>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>Loading sets...</p>
+          </div>
+        ) : error ? (
+          <div style={{ padding: '1.5rem', textAlign: 'center', color: 'var(--accent-red)', fontSize: '0.85rem' }}>
+            Failed to load sets: {error}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div style={{ padding: '1.5rem', textAlign: 'center', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+            {filter.trim() ? 'No sets match your filter.' : 'No sets found for this game.'}
+          </div>
+        ) : (
+          <div className="collection-table-wrapper" style={{ overflowX: 'auto' }}>
+            <table className="collection-table">
+              <thead>
+                <tr>
+                  <th style={{ width: '48px' }}></th>
+                  <th>Set</th>
+                  <th>Release</th>
+                  <th>Cards</th>
+                  <th style={{ width: '110px' }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(s => {
+                  const setCode = bareSetCode(s.id, game);
+                  const key = `${game}|${setCode}`;
+                  const isBuilt = existingSet.has(key);
+                  const isIndexing = buildingSet.has(key) || isActive(progress[key]);
+                  const logo = logoFor(s);
+                  return (
+                    <tr key={s.id}>
+                      <td style={{ padding: '0.25rem' }}>
+                        {logo ? (
+                          <img
+                            src={logo}
+                            alt=""
+                            style={{ width: '36px', height: '36px', objectFit: 'contain', display: 'block', filter: 'invert(1) brightness(1.1)' }}
+                            onError={(e) => { e.target.style.display = 'none'; }}
+                          />
+                        ) : null}
+                      </td>
+                      <td>
+                        <div style={{ fontWeight: 600, color: 'var(--text-strong)' }}>{s.name}</div>
+                        <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', fontFamily: 'monospace' }}>{setCode}</div>
+                      </td>
+                      <td style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{formatDate(s.release_date)}</td>
+                      <td style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{s.printed_total || '-'}</td>
+                      <td>
+                        {isBuilt ? (
+                          <span style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.75rem', color: 'var(--accent-green, #4ade80)' }}>
+                            <CheckCircle2 size={14} /> Indexed
+                          </span>
+                        ) : isIndexing ? (
+                          <span style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.75rem', color: 'var(--accent-yellow)' }}>
+                            <div className="spinner" style={{ width: '14px', height: '14px', margin: 0, borderWidth: '2px' }}></div> Indexing...
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-primary"
+                            style={{ padding: '0.3rem 0.6rem', fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.3rem' }}
+                            onClick={() => handleIndex(game, setCode)}
+                          >
+                            <Play size={12} /> Index Set
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Add Set Browser modal, fix tab-switch crash, and improve set-index management**

## Summary

| Area | Change |
|---|---|
| **New feature** | "Browse Sets" modal in Admin: Set Scan Indexes. Browse all MTG/Pokémon sets with logos, filter by name, one-click index per row, "Index All" bulk button |
| **Bug fix** | Rapid tab switching no longer crashes the app to `about:blank` |
| **Bug fix** | Pokémon sets now populate correctly on fresh installs |
| **Enhancement** | Set names shown in the indexed-sets table (not just codes); collapsible by game |
| **Enhancement** | Game dropdown defaults to user's Settings preference |
| **Enhancement** | "Index Set" in modal queues immediately (no confirm dialog), modal stays open |
| **Robustness** | Async fetch calls guarded against setState-after-unmount during rapid navigation |

## Files changed

| File | What |
|---|---|
| SetBrowserModal.jsx | **New.** Modal with game toggle, search filter, set logo images, per-row "Index Set" and header "Index All" buttons. Sets fetched from new `GET /api/admin/sets-browse` endpoint. |
| AdminPanel.jsx | "Browse Sets" button opens modal. Set names column plus game-grouped collapsible rows in the indexes table. `buildGame` defaults from `localStorage.default_game`. `handleBuildSilent` for no-confirm builds. `mountedRef` guards all async state updates. |
| App.jsx | `goTab()` no longer calls `history.back()` on the previous tab guard. Eliminates the rapid-switch crash. |
| admin.js | New `GET /api/admin/sets-browse?game=` endpoint. Returns sets newest-first with `symbol_url`/`logo_url`. Handles NULL `game` column for backward compat. |
| tcgApi.js | `fetchAndCacheSets` skip-check now counts only Pokémon sets (was counting all sets, causing Pokémon to be skipped if MTG populated first). INSERT now explicitly sets `game = 'pokemon'`. Improved error logging. |

## Details

### 1. Set Browser Modal (new feature)

The Admin Panel's "Set Scan Indexes" section previously required users to manually type a set code (e.g. `mh3` or `sv1`). A new **"Browse Sets"** button opens a modal showing all sets for the selected game, sorted newest-first, with set logo images (inverted for dark mode). Users can:

* Toggle between MTG and Pokémon
* Filter sets by name or ID
* Click **"Index Set"** on any row to start building that set's scan index immediately (no confirmation dialog, modal stays open for queuing multiple sets)
* Click **"Index All"** to index every unbuilt set with a single confirmation

### 2. Rapid tab-switch crash (bug fix)

App.jsx `goTab()` was disposing the previous tab guard by calling `history.back()`. During rapid switching, multiple `history.back()` calls stacked and navigated the browser past the app origin into `about:blank`, crashing the SPA.

**Fix:** `goTab` no longer disposes old guards. Each tab switch simply pushes a fresh history entry. The browser back button correctly walks through tab history.

### 3. Pokémon sets not populating (bug fix)

Two issues in `tcgApi.fetchAndCacheSets()`:

* **Skip check counted ALL sets.** If MTG sets were cached first (or the Pokémon API call failed on a previous run), the count was > 0 and Pokémon fetch was skipped permanently
* **INSERT omitted the `game` column.** Relied on the column DEFAULT, which did not help if the column was added after initial row creation

**Fix:** Skip check now counts `WHERE game = 'pokemon' OR game IS NULL`. INSERT now explicitly sets `game = 'pokemon'`. Admin query also handles `game IS NULL` for backward compat.

### 4. Set names + collapsible game sections (enhancement)

The indexed-sets table now:

* Shows a **"Name" column** with the human-readable set name (e.g. "Modern Horizons 3") fetched from `/api/sets`
* Groups rows under **collapsible game headers** (MTG / Pokémon) with aggregate card count and disk size, click to expand/collapse

### 5. mountedRef guard (robustness)

All six async fetch functions in `AdminPanel` (`fetchBuilds`, `fetchGlobals`, `fetchSetNames`, `fetchUsers`, `fetchSettings`, `fetchBackups`) now check `mountedRef.current` before calling `setState`, preventing React warnings/errors when navigating away before requests complete.

## Testing

* Rapid tab switching (3 rounds x 7 tabs = 21 switches): no crash
* Pokémon sets (174) and MTG sets (1047) populate on fresh install
* Set names displayed, game sections collapsible
* Browse modal: filter, one-click index, Index All with confirmation
* Game dropdown respects user's Settings default