### PR TITLE
fix(modals): cap height + scroll inside panel so actions stay reachable

### DIFF
--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -923,7 +923,7 @@ function AdminPanel({ showToast }) {
           justifyContent: 'center',
           zIndex: 999
         }}>
-          <div className="glass-panel" style={{ maxWidth: '380px', width: '100%', padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+          <div className="glass-panel" style={{ maxWidth: '380px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
             <div>
               <h3 style={{ color: 'var(--text-strong)', fontSize: '1.1rem' }}>Reset Password</h3>
               <p style={{ color: 'var(--text-secondary)', fontSize: '0.8rem' }}>Change password for user: <strong>{targetUser.username}</strong></p>

--- a/frontend/src/components/CameraScanner.jsx
+++ b/frontend/src/components/CameraScanner.jsx
@@ -1363,7 +1363,7 @@ function CameraScanner({ onAddSuccess, showToast }) {
             padding: '1rem'
           }}
         >
-          <div className="glass-panel animate-fade-in" style={{ maxWidth: '420px', width: '100%', padding: '1.75rem', display: 'flex', flexDirection: 'column', gap: '1.25rem', alignItems: 'center', textAlign: 'center', border: '1px solid var(--accent-red)' }}>
+          <div className="glass-panel animate-fade-in" style={{ maxWidth: '420px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '1.75rem', display: 'flex', flexDirection: 'column', gap: '1.25rem', alignItems: 'center', textAlign: 'center', border: '1px solid var(--accent-red)' }}>
             <div>
               <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', textTransform: 'uppercase', letterSpacing: '0.15em', fontWeight: 800 }}>{autoAddEditing ? 'Adjust & Add' : 'Exact Match Identified!'}</span>
               <h3 style={{ fontSize: '1.25rem', color: 'var(--text-strong)', margin: '0.25rem 0 0.5rem 0' }}>{autoAddTargetCard.name}</h3>
@@ -1505,7 +1505,7 @@ function CameraScanner({ onAddSuccess, showToast }) {
             padding: '1rem'
           }}
         >
-          <div className="glass-panel animate-fade-in" style={{ maxWidth: '420px', width: '100%', padding: '1.75rem', display: 'flex', flexDirection: 'column', gap: '1.25rem', alignItems: 'center', textAlign: 'center', border: '1px solid var(--accent-yellow)' }}>
+          <div className="glass-panel animate-fade-in" style={{ maxWidth: '420px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '1.75rem', display: 'flex', flexDirection: 'column', gap: '1.25rem', alignItems: 'center', textAlign: 'center', border: '1px solid var(--accent-yellow)' }}>
             <div>
               <span style={{ fontSize: '0.75rem', color: 'var(--accent-yellow)', textTransform: 'uppercase', letterSpacing: '0.15em', fontWeight: 800 }}>Same card scanned again</span>
               <h3 style={{ fontSize: '1.25rem', color: 'var(--text-strong)', margin: '0.25rem 0 0.5rem 0' }}>{dupConfirmCard.name}</h3>

--- a/frontend/src/components/DeckBuilder.jsx
+++ b/frontend/src/components/DeckBuilder.jsx
@@ -1691,7 +1691,7 @@ function DeckBuilder({ showToast }) {
       {/* A. Create Deck Modal */}
       {showCreateModal && (
         <div className="modal-overlay" style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(6px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 999 }}>
-          <div className="glass-panel" style={{ maxWidth: '480px', width: '100%', padding: '1.75rem', position: 'relative', border: '1px solid rgba(255,255,255,0.15)' }}>
+          <div className="glass-panel" style={{ maxWidth: '480px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '1.75rem', position: 'relative', border: '1px solid rgba(255,255,255,0.15)' }}>
             <button className="btn btn-secondary btn-icon-only" onClick={() => setShowCreateModal(false)} style={{ position: 'absolute', top: '1rem', right: '1rem', borderRadius: '50%' }}>
               <X size={16} />
             </button>
@@ -1929,7 +1929,7 @@ function DeckBuilder({ showToast }) {
       {/* B. Draw Hand Simulator Modal */}
       {showSimulator && (
         <div className="modal-overlay" style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.85)', backdropFilter: 'blur(5px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 999 }}>
-          <div className="glass-panel" style={{ maxWidth: '1000px', width: '100%', padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem', position: 'relative' }}>
+          <div className="glass-panel" style={{ maxWidth: '1000px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem', position: 'relative' }}>
             <button className="btn btn-secondary btn-icon-only" onClick={() => setShowSimulator(false)} style={{ position: 'absolute', top: '1rem', right: '1rem', borderRadius: '50%' }}>
               <X size={16} />
             </button>
@@ -2029,7 +2029,7 @@ function DeckBuilder({ showToast }) {
       {/* C. Export Modal */}
       {showExportModal && (
         <div className="modal-overlay" style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(5px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 999 }}>
-          <div className="glass-panel" style={{ maxWidth: '500px', width: '100%', padding: '1.75rem', position: 'relative' }}>
+          <div className="glass-panel" style={{ maxWidth: '500px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '1.75rem', position: 'relative' }}>
             <button className="btn btn-secondary btn-icon-only" onClick={() => setShowExportModal(false)} style={{ position: 'absolute', top: '1rem', right: '1rem', borderRadius: '50%' }}>
               <X size={16} />
             </button>

--- a/frontend/src/components/LocationManager.jsx
+++ b/frontend/src/components/LocationManager.jsx
@@ -910,8 +910,8 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
       )}
 
       {showRulesModal && selectedLoc && (
-        <div className="modal-overlay" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 100, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <div className="glass-panel" style={{ width: '400px', padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '1rem', background: 'var(--bg-secondary)' }}>
+        <div className="modal-overlay" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 100, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem' }}>
+          <div className="glass-panel" style={{ width: '400px', maxWidth: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '1rem', background: 'var(--bg-secondary)' }}>
             <h3 style={{ margin: 0 }}>Container Settings</h3>
 
             <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.72rem', color: 'var(--text-secondary)' }}>

--- a/frontend/src/components/SharedCollection.jsx
+++ b/frontend/src/components/SharedCollection.jsx
@@ -446,7 +446,7 @@ function SharedCollection({ shareToken }) {
           backgroundColor: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(5px)',
           display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 999, padding: '1rem'
         }} onClick={() => setActiveCard(null)}>
-          <div className="glass-panel" style={{ maxWidth: '680px', width: '100%', padding: '2rem', display: 'flex', flexWrap: 'wrap', gap: '2rem', position: 'relative' }} onClick={(e) => e.stopPropagation()}>
+          <div className="glass-panel" style={{ maxWidth: '680px', width: '100%', maxHeight: '90vh', overflowY: 'auto', overscrollBehavior: 'contain', padding: '2rem', display: 'flex', flexWrap: 'wrap', gap: '2rem', position: 'relative' }} onClick={(e) => e.stopPropagation()}>
             <button className="btn btn-secondary btn-icon-only" onClick={() => setActiveCard(null)} style={{ position: 'absolute', top: '1rem', right: '1rem', borderRadius: '50%' }}>
               <X size={16} />
             </button>


### PR DESCRIPTION
## Problem

Reported: can't scroll to the **Save** button in the edit-container settings popup — the background scrolls instead of the popup.

Root cause: several modal panels are hand-rolled with inline styles and never cap their height (`max-height` + `overflow-y`). On short screens the panel grows past the viewport, so the page scrolls and the panel's bottom (Save/confirm buttons) is unreachable.

## Fix

Add `maxHeight: 90vh` + `overflowY: auto` + `overscrollBehavior: contain` to the panels that can overflow:

- LocationManager — **Container Settings** (the reported one)
- DeckBuilder — Create Deck, Opening Hand Simulator, Export Decklist
- AdminPanel — Reset Password
- SharedCollection — card detail popup
- CameraScanner — auto-add "Adjust & Add" + duplicate-scan confirm

Matches the pattern already used by `CardInspectorModal` (CSS), `CheckoutWizardModal`, `CreateContainerModal`. `overscroll-behavior: contain` stops scroll from chaining to the background.

Already-safe modals left untouched: CheckoutWizard, CreateContainer, CardInspector, scanner search picker + quick-add drawer (all cap via CSS/inline already). The short capacity-sync confirm has fixed content and can't overflow — left as-is.

## Verified

Reproduced the container-settings overflow on a 375x812 mobile viewport: panel now caps at 730px, scrolls internally (scrollHeight 885 > client 729), and the Save button becomes fully visible by scrolling the panel — the page no longer scrolls. Lint clean (`--max-warnings 0`), build passes.

No shared Modal component exists; introducing one would be a larger refactor than this fix warrants, so the established inline pattern was reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)