### PR TITLE
fix(sort): drag-and-drop reordering of sort priority on touch

### DIFF
--- a/frontend/src/components/SortFilterBuilder.jsx
+++ b/frontend/src/components/SortFilterBuilder.jsx
@@ -20,7 +20,7 @@ function SortableItem({ id, children }) {
   };
   return (
     <div ref={setNodeRef} style={style} {...attributes}>
-      <div {...listeners} style={{ cursor: 'grab', display: 'flex', alignItems: 'center' }}>
+      <div {...listeners} style={{ cursor: 'grab', display: 'flex', alignItems: 'center', touchAction: 'none' }}>
         <GripVertical size={16} color="var(--text-muted)" />
       </div>
       <div style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
@@ -52,8 +52,11 @@ const SORT_OPTIONS = [
 export function SortBuilder({ value, onChange }) {
   const items = Array.isArray(value) ? value : [];
   
+  // activationConstraint: touch needs a short press so a tap/scroll on the handle
+  // isn't misread as a drag; distance covers mouse. Without it (plus touch-action:
+  // none on the handle) touch drags never start on mobile.
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 


### PR DESCRIPTION
## Problem

Reported: can't drag-and-drop to rearrange the sort-priority list.

Root cause: the list uses `@dnd-kit`'s `PointerSensor`, but the grip handle had no `touch-action`. On touch devices (the Capacitor mobile app) the browser claims the touch for scrolling, so the pointer sensor never activates and the row won't drag. The now-scrollable settings modal compounds it — the drag gesture reads as a panel scroll.

## Fix

`frontend/src/components/SortFilterBuilder.jsx`:
- `touchAction: 'none'` on the grip handle (dnd-kit's documented requirement for touch drag with PointerSensor).
- `activationConstraint: { distance: 8 }` on the PointerSensor so a tap/scroll on the handle isn't misread as a drag.

## Verified

In the running app: added two sort rules (`name`, `price`), then performed a real pointer drag on the grip. dnd-kit announced the drop over the target droppable and the order changed `[name, price]` → `[price, name]`. Lint clean, build passes.