### PR TITLE
fix: Docker global-index rebuild (EACCES + missing scripts) #17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN npm run build
 FROM node:20-alpine AS production
 WORKDIR /app
 
-# Install native compilation dependencies for SQLite3 (alpine needs build tools)
-RUN apk add --no-cache python3 make g++ 
+# Native build tools for SQLite3, plus su-exec to drop root in the entrypoint.
+RUN apk add --no-cache python3 make g++ su-exec
 
 # Set environment to production
 ENV NODE_ENV=production
@@ -31,9 +31,13 @@ ENV PORT=3001
 ENV DB_PATH=/app/database/pokemon_cards.db
 # Set indexes live on the persisted volume too, else they rebuild every redeploy
 ENV SETS_DIR=/app/database/sets
+# Global scan indexes (embed/orb bins) also live on the persisted volume, both so
+# a rebuild has a writable target under the non-root `node` user and so the
+# multi-GB output survives redeploys instead of being rebuilt each time.
+ENV INDEX_DATA_DIR=/app/database/index
 
-# Create database volume mount target directory
-RUN mkdir -p /app/database
+# Create database volume mount target directory (+ the global-index subdir)
+RUN mkdir -p /app/database/index
 
 # Copy backend configuration
 COPY backend/package*.json ./backend/
@@ -44,6 +48,10 @@ RUN npm ci --omit=dev
 # Copy backend source files
 COPY backend/src/ ./src/
 
+# Global-index build scripts spawned by src/globalIndex.js at runtime (Rebuild
+# Global Index Cache). Omitting these breaks that feature in the image.
+COPY backend/scripts/ ./scripts/
+
 # Shared JSON tables required at runtime by backend/src/utils/compartmentSort.js
 # via ../../../shared/*.json (resolves to /app/shared)
 COPY shared/ /app/shared/
@@ -52,11 +60,17 @@ COPY shared/ /app/shared/
 # (../../frontend/dist relative to backend/src, i.e. /app/frontend/dist)
 COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
 
-# Drop root: run as the built-in unprivileged `node` user. Ownership of the
-# database dir is set here so a fresh named volume mounted at /app/database
-# inherits node-writable permissions on first init.
+# Ownership of the app + database dirs set here so a fresh named volume mounted
+# at /app/database inherits node-writable permissions on first init.
 RUN chown -R node:node /app
-USER node
+
+# The container starts as root and the entrypoint drops to the unprivileged
+# `node` user AFTER chowning the mounted volume (a legacy root-owned volume
+# would otherwise be unwritable). sed strips any CRLF so the shebang works when
+# the file is checked out on Windows.
+COPY entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Expose port
 EXPOSE 3001

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindarr-backend",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "description": "Backend API for Bindarr",
   "main": "src/server.js",
   "scripts": {

--- a/backend/src/embedMatch.js
+++ b/backend/src/embedMatch.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
 
-const DATA_DIR = path.join(__dirname, '..', 'data');
+const DATA_DIR = process.env.INDEX_DATA_DIR || path.join(__dirname, '..', 'data');
 
 let tfPromise = null;      // resolves to { pipeline, RawImage }
 let extractorPromise = null;

--- a/backend/src/globalIndex.js
+++ b/backend/src/globalIndex.js
@@ -10,7 +10,9 @@ const path = require('path');
 const scanMatch = require('./scanMatch');
 const embedMatch = require('./embedMatch');
 
-const DATA_DIR = path.join(__dirname, '..', 'data');
+// INDEX_DATA_DIR points the scan indexes at a persisted, writable location in
+// Docker (the named volume); defaults to backend/data for local dev.
+const DATA_DIR = process.env.INDEX_DATA_DIR || path.join(__dirname, '..', 'data');
 const SCRIPTS_DIR = path.join(__dirname, '..', 'scripts');
 const GAMES = ['mtg', 'pokemon'];
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));

--- a/backend/src/scanMatch.js
+++ b/backend/src/scanMatch.js
@@ -14,7 +14,7 @@ const embedMatch = require('./embedMatch');
 const setIndex = require('./setIndex');
 const { parseSetList } = require('./utils/setQuery');
 
-const DATA_DIR = path.join(__dirname, '..', 'data');
+const DATA_DIR = process.env.INDEX_DATA_DIR || path.join(__dirname, '..', 'data');
 const RECALL_K = 250;      // CLIP candidates to geometrically verify
 const REF_WIDTH = 500;     // must match build-card-orb.mjs
 const DESC_BYTES = 32;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Runs as root, fixes ownership of the persisted volume, then drops to the
+# unprivileged `node` user. A named volume created by an older root-running
+# image is root-owned; without this, the non-root process hits EACCES writing
+# indexes (see issue #17). The stat guard makes the recursive chown a one-time
+# cost: once the top dir is node-owned, later starts skip it.
+set -e
+
+mkdir -p /app/database/index /app/database/sets
+if [ "$(stat -c %U /app/database)" != "node" ]; then
+  echo "entrypoint: taking ownership of /app/database for node user..."
+  chown -R node:node /app/database
+fi
+
+exec su-exec node "$@"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindarr-frontend",
   "private": true,
-  "version": "1.4.37",
+  "version": "1.4.38",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #17.

## Problem
Rebuild Global Index Cache failed in the Docker image:
- `Error: EACCES: permission denied, mkdir '/app/backend/data/.staging-mtg'`
- the `backend/scripts/` build scripts (`build-card-embeddings.mjs`, `build-card-orb.mjs`) that `globalIndex.js` spawns were never copied into the image, so the feature could not run even with perms fixed.

## Fix
- **Ship the scripts**: `COPY backend/scripts/ ./scripts/`.
- **Writable + persisted index dir**: `DATA_DIR` now honors `INDEX_DATA_DIR` (in `globalIndex.js`, `embedMatch.js`, `scanMatch.js`), defaulting to `backend/data` for local dev; Docker sets it to `/app/database/index` on the named volume so the multi-GB output survives redeploys instead of living in ephemeral `/app/backend/data`.
- **Bulletproof ownership**: container now starts as root and an `entrypoint.sh` chowns the mounted volume (one-time, guarded by a `stat` check) then drops to the unprivileged `node` user via `su-exec`. This fixes legacy volumes created by an older root-running image that would otherwise be unwritable.

All build-script deps (`sharp`, `@huggingface/transformers`, `opencv-wasm`, `axios`, `dotenv`) are already prod deps, so `npm ci --omit=dev` keeps them.

## Verification
- Backend tests: 35/35 pass.
- No frontend changes (lint unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)