### PR TITLE
fix: glibc base for onnxruntime-node (#19) + Set Browser modal radius

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,18 @@ RUN npm run build
 # =========================================
 # Stage 2: Set up Production Server
 # =========================================
-FROM node:20-alpine AS production
+# Debian (glibc), NOT alpine: onnxruntime-node (pulled in by
+# @huggingface/transformers for CLIP inference during the global-index build)
+# ships glibc-linked prebuilt binaries and fails to dlopen on alpine/musl
+# (ERR_DLOPEN_FAILED, issue #19).
+FROM node:20-slim AS production
 WORKDIR /app
 
-# Native build tools for SQLite3, plus su-exec to drop root in the entrypoint.
-RUN apk add --no-cache python3 make g++ su-exec
+# Native build tools for SQLite3, gosu to drop root in the entrypoint, plus
+# wget (healthcheck) and ca-certificates (HTTPS to the card APIs + model host).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 make g++ gosu wget ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 # Set environment to production
 ENV NODE_ENV=production
@@ -42,7 +49,7 @@ RUN mkdir -p /app/database/index
 # Copy backend configuration
 COPY backend/package*.json ./backend/
 WORKDIR /app/backend
-# Install production backend dependencies (compiling sqlite3 on alpine)
+# Install production backend dependencies (compiles sqlite3 native addon)
 RUN npm ci --omit=dev
 
 # Copy backend source files
@@ -76,7 +83,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 3001
 
 # Liveness/readiness probe. start-period covers startup (set sync + price job).
-# busybox wget ships with the alpine base image.
+# wget is installed above (slim has no wget by default).
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
   CMD wget -qO- http://localhost:3001/api/health || exit 1
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,4 @@ if [ "$(stat -c %U /app/database)" != "node" ]; then
   chown -R node:node /app/database
 fi
 
-exec su-exec node "$@"
+exec gosu node "$@"

--- a/frontend/src/components/SetBrowserModal.jsx
+++ b/frontend/src/components/SetBrowserModal.jsx
@@ -99,7 +99,7 @@ export default function SetBrowserModal({ game: initialGame, onClose, onStartBui
       onClick={onClose}
     >
       <div
-        style={{ width: '960px', maxWidth: '98vw', maxHeight: '90vh', overflowY: 'auto', padding: '1.25rem', display: 'flex', flexDirection: 'column', gap: '1rem', background: 'var(--bg-primary, #121212)', borderRadius: 'var(--radius-lg, 12px)', border: '1px solid var(--border-glass)', boxShadow: '0 8px 32px rgba(0,0,0,0.5)' }}
+        style={{ width: '960px', maxWidth: '98vw', maxHeight: '90vh', overflowY: 'auto', padding: '1.25rem', display: 'flex', flexDirection: 'column', gap: '1rem', background: 'var(--bg-primary, #121212)', borderRadius: 'var(--radius-md, 12px)', border: '1px solid var(--border-glass)', boxShadow: '0 8px 32px rgba(0,0,0,0.5)' }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Issue #19 — global-index build fails on Docker
`ERR_DLOPEN_FAILED` loading `libonnxruntime.so.1` during Rebuild Global Index Cache. `onnxruntime-node` (pulled in by `@huggingface/transformers` for CLIP inference in the build scripts) ships **glibc**-linked prebuilt binaries and does not run on **alpine/musl**; gcompat shims are unreliable for it.

**Fix:** production stage now uses `node:20-slim` (Debian/glibc). `apk`->`apt-get`, `su-exec`->`gosu`, and `wget`+`ca-certificates` installed (slim ships neither). The EACCES/persistence/entrypoint fixes from v1.4.38 are unchanged.

## Set Browser modal radius
The modal used `var(--radius-lg)` = **999px** in the lcars theme (24px default), which ballooned the panel corners and clipped content. Switched to `var(--radius-md)` to match `.glass-panel`.

## Verification
- Frontend: lint clean, prod build succeeds.
- Backend tests unaffected (no backend src change).
- Note: the multi-hour CLIP build itself was not run here; the base-image swap is the standard resolution for onnxruntime-node's musl incompatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)