### PR TITLE
fix: rebuild sqlite3 from source so the v1.4.40 container starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,14 @@ RUN mkdir -p /app/database/index
 # Copy backend configuration
 COPY backend/package*.json ./backend/
 WORKDIR /app/backend
-# Install production backend dependencies (compiles sqlite3 native addon)
+# Install production backend dependencies (prebuilt native binaries).
 RUN npm ci --omit=dev
+# Recompile ONLY sqlite3 from source: its node-pre-gyp prebuilt is linked
+# against a newer glibc (GLIBC_2.38) than this Debian base provides, so the
+# prebuilt aborts at startup with ERR_DLOPEN_FAILED. Building here links against
+# the image's own glibc. Scoped to sqlite3 so sharp/onnxruntime-node keep their
+# prebuilts (sharp can't build from source without libvips-dev).
+RUN npm rebuild sqlite3 --build-from-source
 
 # Copy backend source files
 COPY backend/src/ ./src/


### PR DESCRIPTION
## Problem
v1.4.40 switched the production image to `node:20-slim` to fix onnxruntime-node (#19). But sqlite3's node-pre-gyp **prebuilt** binary is linked against `GLIBC_2.38`, while Debian bookworm ships **glibc 2.36**:

```
Error: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
  (required by /app/backend/node_modules/sqlite3/build/Release/node_sqlite3.node)
  code: 'ERR_DLOPEN_FAILED'
Node.js v20.20.2
```

The server aborted at require time, so the container crash-looped and the reverse proxy in front of it answered `POST /api/auth/login` with an HTML error page — surfacing in the client as `Unexpected token '<', "<html> <he"... is not valid JSON`.

## Fix
`npm rebuild sqlite3 --build-from-source` after `npm ci`, compiling against the image's own glibc.

Scoped to sqlite3 deliberately: a global `--build-from-source` also makes **sharp** build from source, which fails without `libvips-dev`, and onnxruntime-node's prebuilt is exactly what #19 needed.

## Verification
Built the image locally and ran it:
- Container status: `Up (healthy)`
- `GET /api/health` -> `200 {"status":"ok"}`
- `POST /api/auth/login` bad password -> `401 application/json {"error":"Invalid username or password"}`
- `POST /api/auth/login` real password -> `200` + token

Confirmed the pre-fix image reproduced the exact `ERR_DLOPEN_FAILED` crash above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)