### PR TITLE
Add linux/arm64 support to docker build platforms

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -86,6 +91,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
**1. What this does**
Adds `linux/arm64` as a second build target alongside the existing `linux/amd64`, so the published image works on arm64 hosts (Raspberry Pi, other SBCs, arm64 servers). Uses QEMU emulation via `docker/setup-qemu-action` since this runs on the standard `ubuntu-latest` (amd64) runner.

**2. Changes**
- Added `docker/setup-qemu-action@v3` step (scoped to `arm64` only)
- Added `platforms: linux/amd64,linux/arm64` to the existing `build-push-action` step
- No changes to tagging, caching, or the `verify` job — multi-arch manifest handling is automatic once `platforms` has multiple entries

**3. Tests**
- Ran the modified workflow on my fork via `workflow_dispatch` — both `verify` and `build-and-push` passed, producing a multi-arch manifest
- Pulled the resulting arm64 image on a Raspberry Pi CM5 (`docker image inspect` confirms `arm64` architecture)
- Container starts cleanly, no native-module load errors (`sqlite3` rebuild-from-source works correctly on arm64)
- `/api/health` returns `200 {"status":"ok"}`
- Logged into the web UI and confirmed the frontend renders correctly and tested functionality with app.

**4. Cost**
- QEMU emulation makes the arm64 build leg noticeably slower than amd64, mainly due to `npm rebuild sqlite3 --build-from-source` compiling under emulation. 
- On my fork this resulted in a total CI time of **21 min to build**. 
- If that's a concern, a native-arm64-runner matrix (using GitHub's `ubuntu-24.04-arm` runners) would be faster but is a larger structural change that may be breaking.

As CI build is free on public projects - the extended build time should have minimal downside for wider adoption and availability.

**5. Summary**
- [x] Backward compatible — `linux/amd64` build/tags unchanged
- [x] No Dockerfile changes required
- [x] Tested end-to-end on real arm64 hardware (not just CI)
