### PR TITLE
fix: three frontend/backend bugs (card image spacing, duplicate cards in deck picker, row rename not displaying)

### DIFF
--- a/backend/src/catalog.js
+++ b/backend/src/catalog.js
@@ -422,8 +422,15 @@ async function embedPhase(job) {
   // the whole app bandwidth to fix one pipeline.
   const embedUrl = (row) => row.image_url.replace(/\/low\.png$/, '/high.png');
 
+  // Added header information otherwise scryfall rejects the API call with a 400 error.
   const fetchOne = async (row) => {
-    const res = await fetch(embedUrl(row), { signal: AbortSignal.timeout(30000) });
+    const res = await fetch(embedUrl(row), {
+      signal: AbortSignal.timeout(30000),
+      headers: {
+        'User-Agent': 'Bindarr/1.0 (+https://github.com/thenotoriousJeremy/bindarr)',
+        'Accept': 'image/*',
+      },
+    });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return Buffer.from(await res.arrayBuffer());
   };

--- a/backend/src/utils/compartmentSort.js
+++ b/backend/src/utils/compartmentSort.js
@@ -233,6 +233,7 @@ function isBinderType(type) {
 
 function compartmentLabel(comp, locationType) {
   if (!comp) return 'Unassigned';
+  if (comp.label) return comp.label;
   const noun = isBinderType(locationType) ? 'Page' : 'Row';
   return `${noun} ${comp.idx}`;
 }

--- a/frontend/src/components/DeckBuilder.jsx
+++ b/frontend/src/components/DeckBuilder.jsx
@@ -324,23 +324,39 @@ function DeckBuilder({ showToast }) {
         const res = await fetch(`/api/collection?game=${deckSearchGame}`);
         if (res.ok) {
           const data = await res.json();
-          const mapped = data.map(item => ({
-            id: item.card_id,
-            name: item.name,
-            // Carried through so the picker shows the localized name; `name` stays
-            // English because the 4-copy rule counts by it.
-            printed_name: item.printed_name,
-            set_name: item.set_name,
-            number: item.number || item.collector_number || item.card_number || '',
-            image_url: item.image_url,
-            owned_qty: item.quantity || 1,
-            supertype: item.supertype,
-            subtypes: item.subtypes,
-            types: item.types,
-            colors: item.colors,
-            cmc: item.cmc
-          }));
-          setSearchResults(mapped);
+          // /api/collection returns one row per physical entry (so N copies of
+          // a card = N rows sharing the same card_id). Unlike /api/search
+          // (which GROUPs BY card_id server-side), this endpoint doesn't
+          // aggregate — grouping here mirrors that so browse-mode results have
+          // the same one-row-per-card shape search results already have.
+          // Without this, every row for a given card_id gets marked "added"
+          // together once any one copy is added, and a second owned copy
+          // can't be added at all.
+          const byCardId = new Map();
+          for (const item of data) {
+            const existing = byCardId.get(item.card_id);
+            if (existing) {
+              existing.owned_qty += item.quantity || 1;
+            } else {
+              byCardId.set(item.card_id, {
+                id: item.card_id,
+                name: item.name,
+                // Carried through so the picker shows the localized name; `name` stays
+                // English because the 4-copy rule counts by it.
+                printed_name: item.printed_name,
+                set_name: item.set_name,
+                number: item.number || item.collector_number || item.card_number || '',
+                image_url: item.image_url,
+                owned_qty: item.quantity || 1,
+                supertype: item.supertype,
+                subtypes: item.subtypes,
+                types: item.types,
+                colors: item.colors,
+                cmc: item.cmc
+              });
+            }
+          }
+          setSearchResults(Array.from(byCardId.values()));
         }
       } else {
         const finalQuery = deckSearchGame === 'mtg' ? searchQuery : (translateJapaneseName(searchQuery) || searchQuery);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -787,6 +787,7 @@ button, input, select, textarea {
 }
 
 .tcg-card-image {
+  display:block;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -799,6 +800,7 @@ button, input, select, textarea {
 .collection-row-thumbnail,
 .binder-pocket img,
 .box-coverflow-card img {
+
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;


### PR DESCRIPTION
## Summary

Three unrelated small bugs, bundled together since each is a one-file, low-risk fix. Happy to split into separate PRs if preferred — let me know.

---

### 1. Card image leaving dead space below the colored border

**Symptom:** In the collection viewer, the rarity/type-colored border around each card was taller than the card image itself, leaving a visible blank gap beneath the artwork.

**Cause:** The card `<img>` was rendering as an inline element, which reserves space for descender line-height below the image baseline — the classic inline-image gap.

**Fix:** Set the card image to `display: block` in CSS. This removes the reserved descender space, so the border now hugs the image exactly.

---

### 2. Duplicate cards not selectable in "Add Cards to Deck" via Browse Collection

**Symptom:** When adding cards to a deck via **Browse Collection** (as opposed to the search box), owning multiple copies of the same card caused all copies to appear as separate list entries. Selecting/adding one instantly marked every copy as "added," making it impossible to add a second copy of a card you owned multiples of (e.g. basic lands, energy cards) — unless you used the search box instead, which was unaffected.

**Cause:** `/api/collection` returns one row per physical entry (N copies = N rows sharing the same `card_id`), whereas `/api/search?scope=collection` groups by `card_id` server-side and returns an aggregated `owned_qty`. The Browse Collection code path in `DeckBuilder.jsx` mapped the ungrouped `/api/collection` rows almost directly into the picker list, so the "already added" check — which compares by `card_id` — couldn't distinguish an unused copy from an added one.

**Fix:** Group the Browse Collection results by `card_id` client-side before setting picker state, summing `quantity` into a single `owned_qty` per card — mirroring what `/api/search?scope=collection` already does. This makes both code paths produce the same one-row-per-card shape, so the existing "already added" logic (unchanged) now gets correct input either way.

**Testing:** Verified with a card owned in quantity 2+ — Browse Collection now shows it once with the correct owned count, and both copies can be added to a deck without the picker falsely reporting the second as already used.

---

### 3. Row/page rename not reflected anywhere in the UI

**Symptom:** Using the rename control on a storage box's row (or binder page) appeared to do nothing — the row selector dropdown, row header, and deck-checkout locator all kept showing "Row 1," "Row 2," etc. even after a custom name was set and saved.

**Cause:** The rename *did* save correctly to the `label` column, but every place that displays a row/page reads a separate computed field, `display_label`, built by `compartmentLabel()` in `backend/src/utils/compartmentSort.js`. That function always builds `"Row N"` / `"Page N"` from the row's index and never checked whether a custom `label` had been set — so the saved name was silently discarded at display time everywhere `display_label` is used.

**Fix:** `compartmentLabel()` now returns the custom `label` when one is set, falling back to the numbered `"Row N"` / `"Page N"` format only when it isn't:

```js
function compartmentLabel(comp, locationType) {
  if (!comp) return 'Unassigned';
  if (comp.label) return comp.label;
  const noun = isBinderType(locationType) ? 'Page' : 'Row';
  return `${noun} ${comp.idx}`;
}
```

Since every consumer (row dropdown, row header, checkout locator) reads `display_label` from this single function, this one change fixes the name showing up consistently across the app.

**Testing:** Renamed a row via the existing rename control, confirmed the custom name now appears in the row selector dropdown, the row header, and the deck-checkout locator. Confirmed rows without a custom name still fall back to the numbered label as before.

---

## Notes
- Fully tested on arm hardware before committing.
- No database schema or migration changes — `label` was already being persisted correctly; this only fixes what's read/displayed.
- No API contract changes on `/api/collection` or `/api/search` — fix #2 is entirely client-side.
- Happy to add tests for any of these if there's an existing pattern in `backend/test/` or a frontend test setup I should follow — let me know if there's a preferred approach.