### PR TITLE
feat: stackable binder pockets, true binder spreads, and per-container share links

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -715,6 +715,15 @@ async function initDb() {
     await run(`ALTER TABLE locations ADD COLUMN locked INTEGER NOT NULL DEFAULT 0`);
   }
 
+  // Stacking: on a container with this set, duplicate copies of a card share one
+  // slot instead of claiming one each, so a nine-pocket page holds nine distinct
+  // cards plus however many duplicates of them. Off by default — one card per
+  // slot is what a binder physically is unless the owner sleeves copies together.
+  const locationsStackCols = await all(`PRAGMA table_info(locations)`);
+  if (!locationsStackCols.some(c => c.name === 'allow_stacking')) {
+    await run(`ALTER TABLE locations ADD COLUMN allow_stacking INTEGER NOT NULL DEFAULT 0`);
+  }
+
   // --- PERFORMANCE INDEXES ---
   // `user_id` first, because it is the predicate on essentially every read in the
   // app — every collection query, every stats aggregate — and nothing indexed it.

--- a/backend/src/routes/collection.js
+++ b/backend/src/routes/collection.js
@@ -13,7 +13,7 @@ const cardApi = require('../utils/cardApi');
 const { searchLimiter } = require('../middleware/auth');
 const { resolveCardPrice, parseCardRow, recordPrice } = require('../utils/priceHelpers');
 const { parseSetList } = require('../utils/setQuery');
-const { compartmentLabel, isBinderType, rebalanceCompartmentByScheme } = require('../utils/compartmentSort');
+const { compartmentLabel, isBinderType, rebalanceCompartmentByScheme, stackKey, STACK_KEY_SQL } = require('../utils/compartmentSort');
 const { checkedOutAllocation, resolveCompartmentAndPosition, describePlacement, setStackQuantity } = require('../utils/collectionHelpers');
 const { validateDeckAddition } = require('../utils/deckRules');
 const { splitPrice } = require('../utils/splitPrice');
@@ -939,7 +939,7 @@ router.post('/collection/:id/place', async (req, res) => {
     if (!entry) return res.status(404).json({ error: 'Collection entry not found' });
 
     const comp = await db.get(`
-      SELECT c.id, c.capacity, l.id AS loc_id, l.type AS loc_type, l.sort_order
+      SELECT c.id, c.capacity, l.id AS loc_id, l.type AS loc_type, l.sort_order, l.allow_stacking
       FROM compartments c JOIN locations l ON c.location_id = l.id
       WHERE c.id = ? AND l.user_id = ?`, [compartment_id, req.user.id]);
     if (!comp) return res.status(400).json({ error: 'Invalid compartment' });
@@ -950,6 +950,15 @@ router.post('/collection/:id/place', async (req, res) => {
     if (swap_with) {
       const other = await db.get(`SELECT * FROM collection WHERE id = ? AND user_id = ?`, [swap_with, req.user.id]);
       if (!other) return res.status(400).json({ error: 'Swap target not found' });
+      // Stacking container: dropping a copy onto its own twin joins that pocket
+      // rather than trading places with it — trading two identical cards is a
+      // no-op the user can see no result from.
+      if (comp.allow_stacking && stackKey(entry) === stackKey(other)) {
+        await db.run(`UPDATE collection SET compartment_id = ?, location_id = ?, position = ? WHERE id = ? AND user_id = ?`,
+          [other.compartment_id, other.location_id, other.position, id, req.user.id]);
+        const stackedPlacement = await describePlacement(db, id, req.user.id);
+        return res.json({ message: 'Card stacked', placement: stackedPlacement });
+      }
       await db.run(`UPDATE collection SET compartment_id = ?, location_id = ?, position = ? WHERE id = ? AND user_id = ?`,
         [other.compartment_id, other.location_id, other.position, id, req.user.id]);
       await db.run(`UPDATE collection SET compartment_id = ?, location_id = ?, position = ? WHERE id = ? AND user_id = ?`,
@@ -961,7 +970,10 @@ router.post('/collection/:id/place', async (req, res) => {
     if (!Number.isInteger(slot) || slot < 1) return res.status(400).json({ error: 'Invalid slot' });
 
     if (entry.compartment_id !== compartment_id) {
-      const cnt = await db.get(`SELECT COUNT(*) AS n FROM collection WHERE compartment_id = ? AND user_id = ?`, [compartment_id, req.user.id]);
+      // Slots used, not cards held, once copies are allowed to share a pocket.
+      const cnt = await db.get(
+        `SELECT ${comp.allow_stacking ? `COUNT(DISTINCT ${STACK_KEY_SQL})` : 'COUNT(*)'} AS n
+         FROM collection WHERE compartment_id = ? AND user_id = ?`, [compartment_id, req.user.id]);
       if (cnt.n >= comp.capacity) return res.status(400).json({ error: 'COMPARTMENT_FULL' });
     }
 

--- a/backend/src/routes/shared.js
+++ b/backend/src/routes/shared.js
@@ -1,8 +1,65 @@
 const express = require('express');
 const db = require('../db');
 const { resolveCardPrice, parseCardRow } = require('../utils/priceHelpers');
+const { compartmentLabel } = require('../utils/compartmentSort');
 
 const router = express.Router();
+
+// One container, laid out the way its owner sees it: its pages or rows, and the
+// slot each card sits in — so a shared binder reads as a binder and a shared box
+// as a box, instead of collapsing to a flat card list.
+//
+// Gated on share_locations, not just share_enabled: where a card is stored is
+// exactly what this exposes, and that is the setting the owner opts into.
+router.get('/:share_token/containers/:id', async (req, res) => {
+  const { share_token, id } = req.params;
+  try {
+    const owner = await db.get(`SELECT id, username, share_enabled, share_locations FROM users WHERE share_token = ?`, [share_token]);
+    if (!owner || owner.share_enabled === 0) {
+      return res.status(404).json({ error: 'This card collection is private or does not exist.' });
+    }
+    if (owner.share_locations !== 1) {
+      return res.status(404).json({ error: 'This collection does not share where its cards are stored.' });
+    }
+
+    const location = await db.get(
+      `SELECT id, name, type, sort_order, allow_stacking FROM locations WHERE id = ? AND user_id = ?`,
+      [id, owner.id]
+    );
+    if (!location) return res.status(404).json({ error: 'Container not found.' });
+
+    const compartments = await db.all(
+      `SELECT id, idx, label, capacity FROM compartments WHERE location_id = ? ORDER BY idx ASC`,
+      [location.id]
+    );
+
+    // Same public column set as the collection share above — no purchase price,
+    // no ROI — plus the placement columns the layout is drawn from.
+    const rows = await db.all(`
+      SELECT c.id AS entry_id, c.card_id, c.compartment_id, c.position, c.quantity, c.condition,
+             c.printing, c.language, c.favorite, c.is_trade, c.market_value,
+             cc.name, cc.printed_name, cc.supertype, cc.subtypes, cc.types, cc.rarity,
+             cc.set_id, cc.set_name, cc.number, cc.image_url, cc.game, cc.cmc, cc.color_identity,
+             cc.price_trend, cc.price_normal, cc.price_holofoil, cc.price_reverse_holofoil, cc.price_1st_edition
+      FROM collection c
+      JOIN card_cache cc ON c.card_id = cc.id
+      WHERE c.location_id = ? AND c.user_id = ? AND c.list_type = 'collection'
+      ORDER BY c.position ASC, c.id ASC
+    `, [location.id, owner.id]);
+
+    const cards = rows.map(row => ({ ...parseCardRow(row), price_trend: resolveCardPrice(row) }));
+
+    res.json({
+      owner: owner.username,
+      location,
+      compartments: compartments.map(c => ({ ...c, display_label: compartmentLabel(c, location.type) })),
+      cards
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to retrieve shared container' });
+  }
+});
 
 // Retrieve a shared collection by share token
 router.get('/:share_token', async (req, res) => {

--- a/backend/src/routes/storage.js
+++ b/backend/src/routes/storage.js
@@ -7,7 +7,8 @@ const {
   locationAcceptsCard,
   compartmentAcceptsCard,
   sortCards,
-  rebalanceCompartmentByScheme
+  rebalanceCompartmentByScheme,
+  STACK_KEY_SQL
 } = require('../utils/compartmentSort');
 const { defaultCompartmentPlan, normalizeRuleConfig } = require('../utils/collectionHelpers');
 
@@ -51,7 +52,13 @@ router.get('/locations', async (req, res) => {
       SELECT l.*,
              (SELECT COUNT(*) FROM compartments WHERE location_id = l.id) as compartment_count,
              (SELECT COALESCE(SUM(capacity), 0) FROM compartments WHERE location_id = l.id) as total_capacity,
-             (SELECT COALESCE(SUM(quantity), 0) FROM collection
+             -- Measured against total_capacity, which counts slots: on a stacking
+             -- container the duplicates sharing a pocket are one occupant, so
+             -- counting cards there would report a nine-pocket page as overfull.
+             (SELECT CASE WHEN l.allow_stacking
+                       THEN COUNT(DISTINCT ${STACK_KEY_SQL})
+                       ELSE COALESCE(SUM(quantity), 0) END
+                FROM collection
                 WHERE user_id = l.user_id
                   AND compartment_id IN (SELECT id FROM compartments WHERE location_id = l.id)) as total_cards
       FROM locations l
@@ -120,7 +127,7 @@ router.get('/locations/:id', async (req, res) => {
 
 router.put('/locations/:id', async (req, res) => {
   const { id } = req.params;
-  const { name, type, sort_order, foil_sorting, rule_type, rule_config, game, locked } = req.body;
+  const { name, type, sort_order, foil_sorting, rule_type, rule_config, game, locked, allow_stacking } = req.body;
   if (rule_type !== undefined && !RULE_TYPES.includes(rule_type)) {
     return res.status(400).json({ error: 'Invalid rule_type' });
   }
@@ -167,9 +174,13 @@ router.put('/locations/:id', async (req, res) => {
         rule_type = COALESCE(?, rule_type),
         rule_config = COALESCE(?, rule_config),
         game = COALESCE(?, game),
-        locked = COALESCE(?, locked)
+        locked = COALESCE(?, locked),
+        allow_stacking = COALESCE(?, allow_stacking)
       WHERE id = ? AND user_id = ?
-    `, [name, type, sort_order, foil_sorting, rule_type, ruleConfigJson, game, locked === undefined ? null : (locked ? 1 : 0), id, req.user.id]);
+    `, [name, type, sort_order, foil_sorting, rule_type, ruleConfigJson, game,
+        locked === undefined ? null : (locked ? 1 : 0),
+        allow_stacking === undefined ? null : (allow_stacking ? 1 : 0),
+        id, req.user.id]);
 
     let evicted = 0;
     if (rule_type !== undefined || rule_config !== undefined || game !== undefined) {
@@ -464,12 +475,19 @@ router.post('/locations/:id/recommend-batch', async (req, res) => {
 
       recommendations.push({ entry, recommended });
 
-      workingCompartments = workingCompartments.map(c =>
-        c.id === recommended.compartment_id ? { ...c, count: c.count + 1, free: c.free - 1 } : c
-      );
+      if (!recommended.stacked) {
+        workingCompartments = workingCompartments.map(c =>
+          c.id === recommended.compartment_id ? { ...c, count: c.count + 1, free: c.free - 1 } : c
+        );
+      }
 
+      // card_id and position, not just the display fields: on a stacking
+      // container they are what lets the next copy in this same batch recognise
+      // its twin and land in the pocket this one just claimed.
       mockCards.push({
         entry_id: entry.entry_id,
+        card_id: entry.card_id,
+        position: recommended.position,
         compartment_id: recommended.compartment_id,
         image_url: entry.image_url,
         printing: entry.printing,
@@ -522,9 +540,11 @@ router.post('/locations/:id/apply-all', async (req, res) => {
         id, recommended.compartment_id, recommended.position, entryId, req.user.id
       ]);
 
-      workingCompartments = workingCompartments.map(c =>
-        c.id === recommended.compartment_id ? { ...c, count: c.count + 1, free: c.free - 1 } : c
-      );
+      if (!recommended.stacked) {
+        workingCompartments = workingCompartments.map(c =>
+          c.id === recommended.compartment_id ? { ...c, count: c.count + 1, free: c.free - 1 } : c
+        );
+      }
       filed++;
     }
 
@@ -570,7 +590,7 @@ router.post('/locations/:id/resort', async (req, res) => {
       ]);
       results.push({ entry, recommended });
 
-      if (finalLoc === Number(id)) {
+      if (finalLoc === Number(id) && !recommended.stacked) {
         workingCompartments = workingCompartments.map(c =>
           c.id === recommended.compartment_id ? { ...c, count: c.count + 1, free: c.free - 1 } : c
         );

--- a/backend/src/utils/collectionHelpers.js
+++ b/backend/src/utils/collectionHelpers.js
@@ -2,7 +2,7 @@
 // module so the split route files (collection, storage, importExport) never have
 // to import each other.
 const db = require('../db');
-const { recommendSlot, compartmentLabel, locationAcceptsCard } = require('./compartmentSort');
+const { recommendSlot, compartmentLabel, locationAcceptsCard, STACK_KEY_SQL } = require('./compartmentSort');
 
 // Default compartment plan by container type — used when a caller doesn't
 // specify one at creation time (see POST /locations).
@@ -74,12 +74,14 @@ async function resolveCompartmentAndPosition(arg1, locationId, cardId, userId) {
 
   if (compartmentId !== undefined && compartmentId !== null) {
     const compartment = await db.get(`
-      SELECT c.id, c.idx, c.label, c.capacity, l.id as loc_id, l.type as loc_type, l.name as loc_name FROM compartments c JOIN locations l ON c.location_id = l.id
+      SELECT c.id, c.idx, c.label, c.capacity, l.id as loc_id, l.type as loc_type, l.name as loc_name, l.allow_stacking
+      FROM compartments c JOIN locations l ON c.location_id = l.id
       WHERE c.id = ? AND l.user_id = ?
     `, [compartmentId, uId]);
     if (!compartment) return { compartment_id: null, position: position !== undefined ? position : 0 };
 
-    let countQuery = `SELECT COUNT(*) as cnt FROM collection WHERE compartment_id = ? AND user_id = ?`;
+    // On a stacking container the slot count is what fills up, not the card count.
+    let countQuery = `SELECT ${compartment.allow_stacking ? `COUNT(DISTINCT ${STACK_KEY_SQL})` : 'COUNT(*)'} as cnt FROM collection WHERE compartment_id = ? AND user_id = ?`;
     let countParams = [compartmentId, uId];
     if (excludeEntryId) {
       countQuery += ` AND id != ?`;
@@ -98,11 +100,14 @@ async function resolveCompartmentAndPosition(arg1, locationId, cardId, userId) {
     return { compartment_id: null, position: position !== undefined ? position : 0 };
   }
 
-  const location = await db.get(`SELECT id, name, type, sort_order, foil_sorting, rule_type, rule_config, game, user_id FROM locations WHERE id = ? AND user_id = ?`, [locId, uId]);
+  const location = await db.get(`SELECT id, name, type, sort_order, foil_sorting, rule_type, rule_config, game, allow_stacking, user_id FROM locations WHERE id = ? AND user_id = ?`, [locId, uId]);
   if (!location) return { compartment_id: null, position: 0 };
 
   let cardMetadata = await dbClient.get(`SELECT name, set_name, number, types, subtypes, price_trend, price_normal, price_holofoil, price_reverse_holofoil, supertype, rarity, game, cmc, color_identity FROM card_cache WHERE id = ?`, [cId]);
   if (!cardMetadata) cardMetadata = { name: cId || '', types: [] };
+  // card_cache has no id column selected above, and a stacking container matches
+  // a copy against its twin by card id — so carry it on explicitly.
+  cardMetadata.card_id = cId;
   cardMetadata.printing = printing || 'Normal';
   cardMetadata.language = language || 'English';
   try { cardMetadata.types = JSON.parse(cardMetadata.types || '[]'); } catch { cardMetadata.types = []; }

--- a/backend/src/utils/compartmentSort.js
+++ b/backend/src/utils/compartmentSort.js
@@ -238,10 +238,26 @@ function compartmentLabel(comp, locationType) {
   return `${noun} ${comp.idx}`;
 }
 
+// Which copies share one slot in a container with allow_stacking on: the same
+// printing of the same card in the same language. Condition is deliberately not
+// part of it, matching the collection view's "stack duplicates", which only
+// splits by condition when the owner asks it to. The SQL and JS forms have to
+// agree — one counts occupancy, the other decides where a copy is filed — so
+// both default a legacy NULL the same way.
+const STACK_KEY_SQL = `card_id || '|' || COALESCE(printing, 'Normal') || '|' || COALESCE(language, 'English')`;
+function stackKey(row) {
+  const id = row.card_id !== undefined ? row.card_id : row.id;
+  return `${id}|${row.printing || 'Normal'}|${row.language || 'English'}`;
+}
+
 async function loadCompartments(database, locationId, userId) {
   const dbClient = database || db;
+  // The location's stacking flag rides along rather than being passed in by every
+  // caller: occupancy is the one thing all of them read off these rows, and it
+  // means a different thing on a stacking container (slots used, not cards held).
   const compartments = await dbClient.all(
-    `SELECT * FROM compartments WHERE location_id = ? ORDER BY idx ASC`,
+    `SELECT c.*, l.allow_stacking FROM compartments c JOIN locations l ON c.location_id = l.id
+     WHERE c.location_id = ? ORDER BY c.idx ASC`,
     [locationId]
   );
   if (compartments.length === 0) return [];
@@ -257,8 +273,10 @@ async function loadCompartments(database, locationId, userId) {
     filtersByCompartment.get(r.compartment_id).push(r.category);
   });
 
+  const stacking = compartments.some(c => c.allow_stacking);
   const countRows = await dbClient.all(
-    `SELECT compartment_id, SUM(quantity) as cnt FROM collection WHERE user_id = ? AND compartment_id IN (${placeholders}) GROUP BY compartment_id`,
+    `SELECT compartment_id, ${stacking ? `COUNT(DISTINCT ${STACK_KEY_SQL})` : 'SUM(quantity)'} as cnt
+     FROM collection WHERE user_id = ? AND compartment_id IN (${placeholders}) GROUP BY compartment_id`,
     [userId, ...ids]
   );
   const countByCompartment = new Map(countRows.map(r => [r.compartment_id, r.cnt]));
@@ -326,6 +344,30 @@ async function recommendSlot(database, location, cardMetadata, overrideCompartme
     cardsByCompId.get(c.compartment_id).push(c);
   });
 
+  // Stacking container: a duplicate rides in the pocket its twin already holds,
+  // so it claims no new slot and a full container still accepts it. Checked
+  // before the "everything is full" bail-out below for exactly that reason.
+  if (location.allow_stacking) {
+    const key = stackKey(cardMetadata);
+    const twin = allLocationCards.find(c =>
+      c.position > 0 && compartments.some(comp => comp.id === c.compartment_id) && stackKey(c) === key
+    );
+    if (twin) {
+      const twinComp = compartments.find(comp => comp.id === twin.compartment_id);
+      const seq = Math.max(1, Math.round(twin.position / 1000));
+      return {
+        location_id: location.id,
+        compartment_id: twin.compartment_id,
+        position: twin.position,
+        label: `${compartmentLabel(twinComp, location.type)}, Pos ${seq} (in ${location.name})`,
+        reason: `Stacked with the copy already in ${compartmentLabel(twinComp, location.type)}`,
+        // Batch callers tick a compartment's occupancy down per placement; a
+        // stacked copy takes no slot, so it must not count against capacity.
+        stacked: true
+      };
+    }
+  }
+
   const countOf = (c) => overrideCompartments
     ? (overrideCompartments.find(oc => oc.id === c.id)?.count || 0)
     : (c.count !== undefined ? c.count : (cardsByCompId.get(c.id) || []).reduce((sum, card) => sum + (card.quantity || 1), 0));
@@ -334,7 +376,7 @@ async function recommendSlot(database, location, cardMetadata, overrideCompartme
 
   if (allCompartmentsFull) {
     const otherLocations = await dbClient.all(
-      `SELECT id, name, type, sort_order, foil_sorting, rule_type, rule_config, game, user_id FROM locations WHERE user_id = ? AND id != ? AND locked = 0 ORDER BY id ASC`,
+      `SELECT id, name, type, sort_order, foil_sorting, rule_type, rule_config, game, allow_stacking, user_id FROM locations WHERE user_id = ? AND id != ? AND locked = 0 ORDER BY id ASC`,
       [location.user_id, location.id]
     );
     for (const otherLoc of otherLocations) {
@@ -649,5 +691,7 @@ module.exports = {
   loadSetsCache,
   getSortCategory,
   prepareCardMetadata,
-  safeJsonParse
+  safeJsonParse,
+  stackKey,
+  STACK_KEY_SQL
 };

--- a/backend/test/binderstacking.test.js
+++ b/backend/test/binderstacking.test.js
@@ -1,0 +1,135 @@
+// Stacking containers: duplicate copies share one slot instead of claiming one
+// each (locations.allow_stacking).
+//
+// Three behaviours, and the first two are the ones that make the feature real
+// rather than cosmetic: occupancy has to count slots rather than cards, or a
+// nine-pocket page reports itself full at nine copies of one card; and auto-filing
+// has to send a duplicate to its twin's slot, or the copies never land together in
+// the first place. The third is the manual drop: dropping a copy onto its own twin
+// used to trade the two rows, which is a no-op nobody can see.
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const http = require('http');
+const assert = require('assert');
+
+const tmpDb = path.join(os.tmpdir(), `bindarr-binderstacking-${process.pid}.db`);
+process.env.DB_PATH = tmpDb;
+
+const express = require('express');
+const db = require('../src/db');
+const { loadCompartments, recommendSlot } = require('../src/utils/compartmentSort');
+
+let server;
+
+async function cleanup() {
+  if (server && server.listening) await new Promise(resolve => server.close(resolve));
+  await new Promise(resolve => { try { db.dbConnection.close(() => resolve()); } catch { resolve(); } });
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(tmpDb + suffix); } catch { /* already gone */ }
+  }
+}
+
+function startApp(userId) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => { req.user = { id: userId, role: 'admin' }; next(); });
+  app.use('/api', require('../src/routes/collection'));
+  return new Promise(resolve => {
+    server = http.createServer(app).listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${server.address().port}`));
+  });
+}
+
+async function main() {
+  await db.initDb();
+
+  const user = await db.run(
+    `INSERT INTO users (username, password_hash, role, share_token) VALUES (?, ?, ?, ?)`,
+    ['stacking-test', db.hashPassword('x'), 'admin', `share-${process.pid}`]
+  );
+  const userId = user.lastID;
+  const base = await startApp(userId);
+
+  // A three-pocket page, so "full" is reachable inside one test.
+  const loc = await db.run(
+    `INSERT INTO locations (name, type, sort_order, foil_sorting, rule_type, game, allow_stacking, user_id)
+     VALUES (?, 'Binder', 'custom', 'normals_first', 'any', 'any', 1, ?)`,
+    ['Stacking Binder', userId]
+  );
+  const locId = loc.lastID;
+  const page = await db.run(`INSERT INTO compartments (location_id, idx, capacity) VALUES (?, 1, 3)`, [locId]);
+  const pageId = page.lastID;
+
+  for (const id of ['pika', 'charm']) {
+    await db.run(
+      `INSERT OR REPLACE INTO card_cache (id, name, supertype, subtypes, types, rarity, set_id, set_name, number, image_url, price_trend, game)
+       VALUES (?, ?, 'Pokémon', '[]', '[]', 'Common', 's1', 'Set One', '1', '', 1, 'pokemon')`,
+      [id, id === 'pika' ? 'Pikachu' : 'Charmander']
+    );
+  }
+
+  const addCopy = async (cardId, compartmentId, position) => (await db.run(
+    `INSERT INTO collection (card_id, quantity, condition, printing, language, location_id, compartment_id, position, user_id)
+     VALUES (?, 1, 'Near Mint', 'Normal', 'English', ?, ?, ?, ?)`,
+    [cardId, locId, compartmentId, position, userId]
+  )).lastID;
+
+  // Four Pikachus in one pocket, and the page still has two free pockets.
+  await addCopy('pika', pageId, 1000);
+  await addCopy('pika', pageId, 1000);
+  await addCopy('pika', pageId, 1000);
+  await addCopy('pika', pageId, 1000);
+
+  const comps = await loadCompartments(db, locId, userId);
+  assert.strictEqual(comps[0].count, 1, `four copies in one pocket must count as one slot, got ${comps[0].count}`);
+  assert.strictEqual(comps[0].free, 2, `a three-pocket page with one slot used has two free, got ${comps[0].free}`);
+  console.log('PASS: occupancy counts slots used, not cards held');
+
+  // Auto-filing a fifth Pikachu joins the pocket the others are in.
+  const location = await db.get(`SELECT * FROM locations WHERE id = ?`, [locId]);
+  const stacked = await recommendSlot(db, location, {
+    card_id: 'pika', name: 'Pikachu', printing: 'Normal', language: 'English', types: [], supertype: 'Pokémon'
+  });
+  assert.strictEqual(stacked.compartment_id, pageId, 'a duplicate must be filed on the page its twin is on');
+  assert.strictEqual(stacked.position, 1000, `a duplicate must take its twin's slot, got ${stacked.position}`);
+  assert.strictEqual(stacked.stacked, true, 'a stacked recommendation must say so, so batch filing does not charge it a slot');
+
+  // A different card is not a duplicate: it gets a slot of its own.
+  const fresh = await recommendSlot(db, location, {
+    card_id: 'charm', name: 'Charmander', printing: 'Normal', language: 'English', types: [], supertype: 'Pokémon'
+  });
+  assert.notStrictEqual(fresh.position, 1000, 'a different card must not be stacked onto the Pikachu pocket');
+  assert.ok(!fresh.stacked, 'a card with no twin here is not a stacked placement');
+  console.log('PASS: auto-filing sends a duplicate to its twin\'s slot and nothing else');
+
+  // Manual drop of a copy onto its own twin: stacks rather than swapping.
+  const loose = await addCopy('pika', null, 0);
+  const twin = await db.get(`SELECT id FROM collection WHERE compartment_id = ? AND card_id = 'pika' LIMIT 1`, [pageId]);
+  const res = await fetch(`${base}/api/collection/${loose}/place`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ compartment_id: pageId, slot: 1, swap_with: twin.id }),
+  });
+  assert.strictEqual(res.status, 200, `dropping onto a twin must succeed, got ${res.status}`);
+  const placed = await db.get(`SELECT compartment_id, position FROM collection WHERE id = ?`, [loose]);
+  assert.strictEqual(placed.compartment_id, pageId, 'the dropped copy must land on the page');
+  assert.strictEqual(placed.position, 1000, `the dropped copy must share the twin's slot, got ${placed.position}`);
+  const twinAfter = await db.get(`SELECT compartment_id, position FROM collection WHERE id = ?`, [twin.id]);
+  assert.strictEqual(twinAfter.compartment_id, pageId, 'the twin must not be pushed out of the binder by the drop');
+  assert.strictEqual(twinAfter.position, 1000, 'the twin must stay in its own slot');
+  console.log('PASS: dropping a copy onto its twin stacks instead of swapping');
+
+  // Same page with stacking off: the four copies are four cards against capacity.
+  await db.run(`UPDATE locations SET allow_stacking = 0 WHERE id = ?`, [locId]);
+  const plain = await loadCompartments(db, locId, userId);
+  assert.strictEqual(plain[0].count, 5, `without stacking every copy counts, got ${plain[0].count}`);
+  console.log('PASS: with stacking off, occupancy is the card count again');
+}
+
+main()
+  .then(() => cleanup())
+  .catch(async err => {
+    console.error('FAIL:', err.stack || err.message);
+    await cleanup();
+    process.exitCode = 1;
+  });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ const Settings = lazy(() => import('./components/Settings'));
 const AdminPanel = lazy(() => import('./components/AdminPanel'));
 const SetupWizard = lazy(() => import('./components/SetupWizard'));
 const SharedCollection = lazy(() => import('./components/SharedCollection'));
+const SharedContainer = lazy(() => import('./components/SharedContainer'));
 const DeckBuilder = lazy(() => import('./components/DeckBuilder'));
 const Notes = lazy(() => import('./components/Notes'));
 
@@ -127,6 +128,10 @@ function App() {
     const match = path.match(/^\/share\/([a-zA-Z0-9_-]+)$/);
     return match ? match[1] : null;
   });
+  const [sharedContainerId] = useState(() => {
+    const id = new URLSearchParams(window.location.search).get('container');
+    return /^\d+$/.test(id || '') ? id : null;
+  });
 
   const showToast = (message) => {
     setToast(message);
@@ -221,11 +226,14 @@ function App() {
     setStatsTrigger(prev => prev + 1);
   };
 
-  // Render shared collection view if URL matches /share/:token
+  // Render shared collection view if URL matches /share/:token. ?container=<id>
+  // narrows it to one binder or box, drawn as that container rather than a list.
   if (shareToken) {
     return (
       <Suspense fallback={<ChunkFallback />}>
-        <SharedCollection shareToken={shareToken} />
+        {sharedContainerId
+          ? <SharedContainer shareToken={shareToken} containerId={sharedContainerId} />
+          : <SharedCollection shareToken={shareToken} />}
       </Suspense>
     );
   }

--- a/frontend/src/components/CompartmentView.jsx
+++ b/frontend/src/components/CompartmentView.jsx
@@ -17,6 +17,27 @@ function pocketColumns(capacity) {
   return Math.max(1, Math.round(Math.sqrt(capacity || 1)));
 }
 
+// Collapse copies of the same card into one pocket, keyed the way the server
+// counts occupancy on a stacking container (card, printing and language; not
+// condition). The first copy holds the slot and the rest ride along in its
+// quantity, so the page lays out from stacks rather than from rows.
+function stackPocketCards(cards) {
+  const stacks = new Map();
+  for (const card of cards) {
+    const key = `${card.card_id}|${card.printing || 'Normal'}|${card.language || 'English'}`;
+    const held = stacks.get(key);
+    if (!held) {
+      stacks.set(key, { ...card, quantity: card.quantity || 1 });
+      continue;
+    }
+    held.quantity += card.quantity || 1;
+    // Whichever copy is actually filed decides where the stack sits; an unplaced
+    // one joining it must not drag the pocket back to "no position".
+    if (!(held.position > 0) && card.position > 0) held.position = card.position;
+  }
+  return Array.from(stacks.values());
+}
+
 // The label a card falls under for a given divider field.
 function categoryForField(card, field, setsList = []) {
   switch (field) {
@@ -257,6 +278,9 @@ export default function CompartmentView({
   compartment,
   cards = [],
   locationType,
+  // Container has allow_stacking: every copy of a card shares one pocket instead
+  // of taking one each. See stackPocketCards.
+  allowStacking = false,
   sortOrder = 'custom',
   setsList = [],
   highlightPositions = [], // Array of positions to highlight (1-indexed)
@@ -473,8 +497,9 @@ export default function CompartmentView({
 
   if (isBinder) {
     const cols = pocketColumns(compartment.capacity);
+    const pocketCards = allowStacking ? stackPocketCards(cards) : cards;
     let maxSlotFromCards = compartment.capacity || 1;
-    cards.forEach(c => {
+    pocketCards.forEach(c => {
       if (c && c.position > 0) {
         const s = Math.floor(c.position / 1000);
         if (s > maxSlotFromCards) maxSlotFromCards = s;
@@ -487,7 +512,7 @@ export default function CompartmentView({
     const pockets = new Array(slotCount).fill(null);
     const unplaced = [];
 
-    cards.forEach(c => {
+    pocketCards.forEach(c => {
       const slot = (c && c.position > 0) ? Math.floor(c.position / 1000) : null;
       if (slot && slot >= 1 && slot <= slotCount && !pockets[slot - 1]) {
         pockets[slot - 1] = c;
@@ -675,6 +700,11 @@ export default function CompartmentView({
                   <CardImage card={card} alt={displayName(card)} title={displayName(card)} loading="lazy" decoding="async" />
                   {getFoilOverlayClass(card.printing) && <div className={getFoilOverlayClass(card.printing)} style={{ borderRadius: '4px' }} />}
                   <PrintingBadge printing={card.printing} />
+                  {allowStacking && card.quantity > 1 && (
+                    <span title={t('compartment.stackedHere', { count: card.quantity })} style={{ position: 'absolute', bottom: '3px', left: '3px', zIndex: 24, fontSize: '0.6rem', fontWeight: 900, padding: '1px 4px', borderRadius: '4px', background: 'rgba(0,0,0,0.75)', border: '1px solid var(--border-glass-hover)', color: 'var(--text-strong)' }}>
+                      &times;{card.quantity}
+                    </span>
+                  )}
                   {(pullMode ? pulledSet.has(card.entry_id) : card.checked_out_qty > 0) && (
                     <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.62)', borderRadius: '4px', zIndex: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', pointerEvents: 'none' }}>
                       <span style={{ fontSize: '0.5rem', fontWeight: 900, letterSpacing: '0.04em', color: 'var(--text-strong)', background: 'var(--accent-red)', padding: '2px 5px', borderRadius: '4px', transform: 'rotate(-8deg)', textTransform: 'uppercase' }}>

--- a/frontend/src/components/LocationManager.jsx
+++ b/frontend/src/components/LocationManager.jsx
@@ -6,7 +6,7 @@ import { getFoilOverlayClass, getPrintingBadgeLabel, getPrintingBadgeStyle } fro
 import { getCardRarityBorder, getRarityBadgeStyle, getRarityBadgeLabel } from '../utils/cardRarity';
 import CardInspectorModal from './CardInspectorModal';
 import { useMultiSelect } from '../utils/useMultiSelect';
-import { isBinderType as computeIsBinder } from '../utils/cardOptions';
+import { isBinderType as computeIsBinder, binderSpread } from '../utils/cardOptions';
 import { displayName } from '../utils/languages';
 import CompartmentView, { FocusedCardInfo } from './CompartmentView';
 import { SortBuilder, FilterBuilder } from './SortFilterBuilder';
@@ -90,6 +90,7 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
   const [nameDraft, setNameDraft] = useState('');
   const [capacityDraft, setCapacityDraft] = useState('');
   const [countDraft, setCountDraft] = useState('');
+  const [stackingDraft, setStackingDraft] = useState(false);
 
   const [inspectorCard, setInspectorCard] = useState(null);
 
@@ -920,6 +921,7 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
       sort_order: newSort,
       rule_type: filterDraft.length > 0 ? 'compound' : 'any',
       rule_config: filterDraft.length > 0 ? JSON.stringify({ rules: filterDraft }) : null,
+      allow_stacking: stackingDraft,
     };
     const trimmedName = (nameDraft || '').trim();
     if (trimmedName && trimmedName !== selectedLoc.name) fields.name = trimmedName;
@@ -1077,8 +1079,32 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
               </label>
             </div>
 
+            {/* Binders only: a box row shows its cards in a coverflow, where a
+                shared slot has nothing to show — the pocket grid is what makes a
+                stack visible. */}
+            {isBinderType && (
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  id="allowStackingOpt"
+                  checked={stackingDraft}
+                  onChange={(e) => setStackingDraft(e.target.checked)}
+                  style={{ width: '16px', height: '16px', cursor: 'pointer', marginTop: '0.1rem', flexShrink: 0 }}
+                />
+                <label htmlFor="allowStackingOpt" style={{ cursor: 'pointer', margin: 0, fontSize: '0.75rem', color: 'var(--text-primary)', lineHeight: 1.35 }}>
+                  <strong>{t('loc.allowStacking')}</strong>
+                  <span style={{ display: 'block', color: 'var(--text-muted)', fontSize: '0.7rem' }}>
+                    {t('loc.allowStackingHint')}
+                  </span>
+                </label>
+              </div>
+            )}
+
             <div style={{ background: 'var(--bg-tertiary, rgba(255,255,255,0.04))', borderRadius: 'var(--radius-sm)', padding: '0.4rem 0.55rem', fontSize: '0.72rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <span style={{ color: 'var(--text-muted)' }}>{t('loc.cardsCurrentlyStored')}</span>
+              {/* Label only — the count sits in the value beside it, so this is
+                  not loc.cardsCurrentlyStored, whose sentence carries a {count}
+                  this row has nowhere to put. */}
+              <span style={{ color: 'var(--text-muted)' }}>{t(selectedLoc.allow_stacking ? 'loc.slotsUsedLabel' : 'loc.cardsStoredLabel')}</span>
               <strong style={{ fontSize: '0.9rem', color: 'var(--text-strong)' }}>{selectedLoc.total_cards || 0} / {selectedLoc.total_capacity || 0}</strong>
             </div>
 
@@ -1222,6 +1248,7 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                     setFilterDraft(fDraft);
 
                     setNameDraft(selectedLoc.name || '');
+                    setStackingDraft(!!selectedLoc.allow_stacking);
                     setCountDraft(String(compartments.length));
                     const caps = compartments.map(c => c.capacity);
                     const uniform = caps.length > 0 && caps.every(c => c === caps[0]);
@@ -1306,10 +1333,14 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                   type="button"
                   className="btn btn-secondary"
                   disabled={activePageIndex <= 0}
-                  onClick={() => setActivePageIndex(prev => Math.max(0, isMobile ? prev - 1 : prev - 2))}
+                  onClick={() => setActivePageIndex(prev => {
+                    if (isMobile) return Math.max(0, prev - 1);
+                    const { spread } = binderSpread(prev);
+                    return spread <= 1 ? 0 : (spread - 1) * 2 - 1;
+                  })}
                   style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
                 >
-                  &larr; Prev
+                  {t('loc.prev')}
                 </button>
                 <select
                   className="select-control"
@@ -1333,9 +1364,13 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                 <button
                   type="button"
                   className="btn btn-secondary"
-                  disabled={isMobile ? activePageIndex >= compartments.length - 1 : Math.floor(activePageIndex / 2) * 2 + 2 >= compartments.length}
+                  disabled={isMobile
+                    ? activePageIndex >= compartments.length - 1
+                    : binderSpread(activePageIndex).spread * 2 + 1 >= compartments.length}
                   onClick={() => setActivePageIndex(prev => {
-                    const next = isMobile ? prev + 1 : prev + 2;
+                    // Next spread's left page — the opening spread has none, so
+                    // stepping off page 1 lands on page 2.
+                    const next = isMobile ? prev + 1 : binderSpread(prev).spread * 2 + 1;
                     return next < compartments.length ? next : prev;
                   })}
                   style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
@@ -1351,6 +1386,7 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                 const pageProps = (c, i) => ({
                   compartment: c,
                   cards: cardsByCompartment.get(c.id) || [],
+                  allowStacking: !!selectedLoc.allow_stacking,
                   sortOrder: selectedLoc.sort_order,
                   setsList,
                   canRemove: i === compartments.length - 1 && compartments.length > 1 && (cardsByCompartment.get(c.id) || []).length === 0,
@@ -1404,23 +1440,22 @@ function LocationManager({ statsTrigger, onUpdate, showToast, selectedLocationId
                     </div>
                   );
                 } else {
-                  const spreadIdx = Math.floor(Math.min(activePageIndex, compartments.length - 1) / 2);
-                  const leftIdx = spreadIdx * 2;
-                  const rightIdx = leftIdx + 1;
-                  const left = compartments[leftIdx];
+                  const { leftIdx, rightIdx } = binderSpread(Math.min(activePageIndex, compartments.length - 1));
+                  const left = leftIdx >= 0 ? compartments[leftIdx] : null;
                   const right = compartments[rightIdx];
 
+                  // The missing half of an opening or closing spread still holds
+                  // its side of the binder, so the page that is there stays on
+                  // its own side of the spine instead of sliding across it.
                   binderPages = (
                     <div className="binder-page-container">
                       <div className="binder-page-left">
-                        <CompartmentView {...pageProps(left, leftIdx)} locationType={selectedLoc.type} />
+                        {left && <CompartmentView {...pageProps(left, leftIdx)} locationType={selectedLoc.type} />}
                       </div>
                       <div className="binder-spine" />
-                      {right && (
-                        <div className="binder-page-right">
-                          <CompartmentView {...pageProps(right, rightIdx)} locationType={selectedLoc.type} />
-                        </div>
-                      )}
+                      <div className="binder-page-right">
+                        {right && <CompartmentView {...pageProps(right, rightIdx)} locationType={selectedLoc.type} />}
+                      </div>
                     </div>
                   );
                 }

--- a/frontend/src/components/MultiSelectDropdown.jsx
+++ b/frontend/src/components/MultiSelectDropdown.jsx
@@ -1,11 +1,13 @@
 import { useState, useRef, useEffect } from 'react';
-import { ChevronDown, Check } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
+import { useT } from '../utils/i18n';
 
 // A reusable checklist dropdown, standing in for a native <select> wherever
 // a filter should allow choosing several values at once instead of one.
 // `value` is always an array; an empty array means "no filter applied" (same
 // meaning as '' on the single-select version it replaces).
 export default function MultiSelectDropdown({ label, options, value, onChange, allLabel }) {
+  const { t } = useT();
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
 
@@ -29,7 +31,7 @@ export default function MultiSelectDropdown({ label, options, value, onChange, a
     ? allLabel
     : value.length === 1
       ? (options.find(o => o.value === value[0])?.label ?? value[0])
-      : `${value.length} selected`;
+      : t('bulk.selected', { count: value.length });
 
   return (
     <div ref={ref} style={{ position: 'relative' }}>
@@ -48,12 +50,11 @@ export default function MultiSelectDropdown({ label, options, value, onChange, a
 
       {open && (
         <div
-          role="listbox"
           style={{
             position: 'absolute', top: 'calc(100% + 4px)', left: 0, zIndex: 20,
             minWidth: '100%', maxHeight: '260px', overflowY: 'auto',
-            background: 'var(--bg-elevated, #1c1c1e)', border: '1px solid var(--border-glass)',
-            borderRadius: '8px', padding: '0.35rem', boxShadow: '0 8px 24px rgba(0,0,0,0.35)'
+            background: 'var(--bg-secondary)', border: '1px solid var(--border-glass)',
+            borderRadius: 'var(--radius-sm)', padding: '0.35rem', boxShadow: 'var(--shadow-glow)'
           }}
         >
           {value.length > 0 && (
@@ -63,33 +64,25 @@ export default function MultiSelectDropdown({ label, options, value, onChange, a
               style={{ width: '100%', fontSize: '0.72rem', padding: '0.3rem', marginBottom: '0.3rem' }}
               onClick={() => onChange([])}
             >
-              Clear ({value.length})
+              {t('bulk.clear')}
             </button>
           )}
-          {options.map(opt => {
-            const checked = value.includes(opt.value);
-            return (
-              <label
-                key={opt.value}
-                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.35rem 0.4rem', borderRadius: '5px', cursor: 'pointer', fontSize: '0.82rem' }}
-              >
-                <span style={{
-                  width: '16px', height: '16px', borderRadius: '4px', flexShrink: 0,
-                  border: '1px solid var(--border-glass)', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  background: checked ? 'var(--accent-red)' : 'transparent'
-                }}>
-                  {checked && <Check size={12} color="white" />}
-                </span>
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={() => toggle(opt.value)}
-                  style={{ display: 'none' }}
-                />
-                {opt.label}
-              </label>
-            );
-          })}
+          {/* Native checkboxes rather than a styled div: keyboard reachable and
+              announced without a roving-tabindex listbox of our own. */}
+          {options.map(opt => (
+            <label
+              key={opt.value}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.35rem 0.4rem', borderRadius: '5px', cursor: 'pointer', fontSize: '0.82rem' }}
+            >
+              <input
+                type="checkbox"
+                checked={value.includes(opt.value)}
+                onChange={() => toggle(opt.value)}
+                style={{ width: '14px', height: '14px', flexShrink: 0, cursor: 'pointer', accentColor: 'var(--accent-red)' }}
+              />
+              {opt.label}
+            </label>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -57,6 +57,7 @@ function Settings({ user, onUpdateUser, showToast }) {
   const [shareEnabled, setShareEnabled] = useState(user?.share_enabled === 1);
   const [shareLocations, setShareLocations] = useState(user?.share_locations === 1);
   const [shareLoading, setShareLoading] = useState(false);
+  const [containers, setContainers] = useState([]);
 
   const [tcgApiKey, setTcgApiKey] = useState(user?.tcg_api_key || '');
   const [psaToken, setPsaToken] = useState(user?.psa_api_token || '');
@@ -212,6 +213,16 @@ function Settings({ user, onUpdateUser, showToast }) {
     reader.readAsText(file);
     e.target.value = null;
   };
+
+  // Containers to offer share links for. Only fetched once both share toggles are
+  // on, because that is the only state the links work in.
+  useEffect(() => {
+    if (!shareEnabled || !shareLocations) { setContainers([]); return; }
+    fetch('/api/locations')
+      .then(res => (res.ok ? res.json() : []))
+      .then(list => setContainers(Array.isArray(list) ? list : []))
+      .catch(() => setContainers([]));
+  }, [shareEnabled, shareLocations]);
 
   useEffect(() => {
     if (user) {
@@ -433,10 +444,12 @@ function Settings({ user, onUpdateUser, showToast }) {
 
   const [copiedType, setCopiedType] = useState(''); // 'collection', 'trade', 'wishlist'
 
-  const copyToClipboard = (url, type) => {
+  // messageType is separate from type because the per-container rows key their
+  // "copied" tick by container id, while sharing one toast message.
+  const copyToClipboard = (url, type, messageType = type) => {
     navigator.clipboard.writeText(url).then(() => {
       setCopiedType(type);
-      showToast(t(`settings.copied.${type}`));
+      showToast(t(`settings.copied.${messageType}`));
       setTimeout(() => setCopiedType(''), 2000);
     }).catch(() => {
       showToast(t('settings.errCopy'));
@@ -594,6 +607,32 @@ function Settings({ user, onUpdateUser, showToast }) {
                   </span>
                 </label>
               </div>
+
+              {/* A container link opens that binder or box as itself — pockets
+                  and pages, or box rows — rather than as a flat card list, which
+                  is why it needs the locations toggle above to be on. */}
+              {shareLocations && containers.length > 0 && (
+                <div className="form-group" style={{ marginBottom: 0 }}>
+                  <label>{t('settings.linkContainer')}</label>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                    {containers.map(loc => (
+                      <div key={loc.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        <span style={{ flex: 1, fontSize: '0.8rem', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {loc.name}
+                        </span>
+                        <button
+                          className="btn btn-secondary"
+                          onClick={() => copyToClipboard(`${origin}/share/${user?.share_token}?container=${loc.id}${themeQuery}`, `container-${loc.id}`, 'container')}
+                          style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', whiteSpace: 'nowrap' }}
+                        >
+                          {copiedType === `container-${loc.id}` ? <Check size={14} style={{ color: 'var(--type-grass)' }} /> : <Clipboard size={14} />}
+                          <span>{t('settings.copy')}</span>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
                 <button

--- a/frontend/src/components/SharedContainer.jsx
+++ b/frontend/src/components/SharedContainer.jsx
@@ -38,7 +38,7 @@ function SharedContainer({ shareToken, containerId }) {
       }
     };
     fetchContainer();
-  }, [shareToken, containerId]);
+  }, [shareToken, containerId, t]);
 
   const cardsByCompartment = useMemo(() => {
     const byComp = new Map();

--- a/frontend/src/components/SharedContainer.jsx
+++ b/frontend/src/components/SharedContainer.jsx
@@ -1,0 +1,156 @@
+import { useState, useEffect, useMemo } from 'react';
+import { ShieldAlert } from 'lucide-react';
+import Logo from './Logo';
+import { isBinderType, binderSpread } from '../utils/cardOptions';
+import CompartmentView from './CompartmentView';
+import { useT } from '../utils/i18n';
+
+// A single shared container, drawn with the same CompartmentView the owner sees:
+// a binder gets its pocket spread, a box its coverflow. Read-only — no callbacks
+// are passed, so CompartmentView renders no rename, capacity or lock controls.
+function SharedContainer({ shareToken, containerId }) {
+  const { t } = useT();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [pageIndex, setPageIndex] = useState(0);
+
+  useEffect(() => {
+    const urlTheme = new URLSearchParams(window.location.search).get('theme');
+    if (urlTheme) document.documentElement.setAttribute('data-theme', urlTheme);
+  }, []);
+
+  useEffect(() => {
+    const fetchContainer = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await fetch(`/api/shared/${shareToken}/containers/${containerId}`);
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}));
+          throw new Error(errData.error || t('shared.errLoadContainer'));
+        }
+        setData(await res.json());
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchContainer();
+  }, [shareToken, containerId]);
+
+  const cardsByCompartment = useMemo(() => {
+    const byComp = new Map();
+    for (const card of (data?.cards || [])) {
+      if (!card.compartment_id) continue;
+      if (!byComp.has(card.compartment_id)) byComp.set(card.compartment_id, []);
+      byComp.get(card.compartment_id).push(card);
+    }
+    return byComp;
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '80vh' }}>
+        <div className="spinner"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '80vh', padding: '1rem' }}>
+        <div className="glass-panel" style={{ textAlign: 'center', maxWidth: '400px', width: '100%', padding: '2.5rem 1.5rem', border: '1px solid rgba(255, 71, 71, 0.2)' }}>
+          <ShieldAlert size={48} style={{ color: 'var(--accent-red)', marginBottom: '1rem' }} />
+          <h2 style={{ color: 'var(--text-strong)', fontSize: '1.25rem', marginBottom: '0.5rem' }}>{t('shared.unavailable')}</h2>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>{error}</p>
+          <a href="/" style={{
+            display: 'inline-block', marginTop: '1.5rem', padding: '0.5rem 1.5rem',
+            backgroundColor: 'var(--accent-red)', color: 'var(--text-strong)',
+            textDecoration: 'none', fontWeight: 700, borderRadius: 'var(--radius-sm)', boxShadow: 'var(--shadow-accent)'
+          }}>
+            {t('shared.goToBindarr')}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  const { location, compartments = [], owner } = data;
+  const binder = isBinderType(location.type);
+  const pageProps = (compartment) => ({
+    compartment,
+    cards: cardsByCompartment.get(compartment.id) || [],
+    allowStacking: !!location.allow_stacking,
+    sortOrder: location.sort_order,
+    locationType: location.type,
+  });
+
+  // Binders page through a spread at a time; a box shows one row at a time, the
+  // same unit the owner's view scrolls through.
+  const { leftIdx, rightIdx, spread } = binderSpread(Math.min(pageIndex, compartments.length - 1));
+  const left = binder && leftIdx >= 0 ? compartments[leftIdx] : null;
+  const right = binder ? compartments[rightIdx] : null;
+  const activeRow = compartments[Math.min(pageIndex, compartments.length - 1)];
+  const nextIndex = binder ? spread * 2 + 1 : pageIndex + 1;
+  const prevIndex = binder ? (spread <= 1 ? 0 : (spread - 1) * 2 - 1) : pageIndex - 1;
+
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '1rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+        <Logo size={34} />
+        <div>
+          <h1 style={{ margin: 0, fontSize: '1.2rem', color: 'var(--text-strong)' }}>{location.name}</h1>
+          <span style={{ fontSize: '0.78rem', color: 'var(--text-secondary)' }}>{t('shared.sharedBy')} {owner}</span>
+        </div>
+      </div>
+
+      {compartments.length === 0 ? (
+        <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{t('loc.noCompartments')}</p>
+      ) : (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '1rem', background: 'rgba(0,0,0,0.1)', padding: '0.4rem', borderRadius: 'var(--radius-sm)' }}>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              disabled={pageIndex <= 0}
+              onClick={() => setPageIndex(Math.max(0, prevIndex))}
+              style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+            >
+              {t('loc.prev')}
+            </button>
+            <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-secondary)' }}>
+              {(binder ? (right || left) : activeRow)?.display_label}
+            </span>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              disabled={nextIndex >= compartments.length}
+              onClick={() => setPageIndex(nextIndex)}
+              style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+            >
+              {t('loc.next')}
+            </button>
+          </div>
+
+          {binder ? (
+            <div className="binder-page-container">
+              <div className="binder-page-left">
+                {left && <CompartmentView {...pageProps(left)} />}
+              </div>
+              <div className="binder-spine" />
+              <div className="binder-page-right">
+                {right && <CompartmentView {...pageProps(right)} />}
+              </div>
+            </div>
+          ) : (
+            activeRow && <CompartmentView {...pageProps(activeRow)} />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default SharedContainer;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1410,5 +1410,14 @@
   "wizard.nothingToMove": "Keine Karten zu bewegen.",
   "wizard.page": "Seite",
   "wizard.selectAll": "Alle auswählen",
-  "wizard.slot": "Platz {slot}"
+  "wizard.slot": "Platz {slot}",
+  "loc.prev": "← Zurück",
+  "loc.allowStacking": "Duplikate in einer Hülle stapeln",
+  "loc.allowStackingHint": "Mehrere Exemplare derselben Karte teilen eine Hülle und zeigen eine Anzahl, sodass eine Seite entsprechend mehr verschiedene Karten fasst.",
+  "loc.cardsStoredLabel": "Gespeicherte Karten",
+  "loc.slotsUsedLabel": "Belegte Plätze",
+  "compartment.stackedHere": "{count} Exemplare in dieser Hülle gestapelt",
+  "settings.linkContainer": "Freigabelinks für Container",
+  "settings.copied.container": "Öffentlicher Container-Link in die Zwischenablage kopiert.",
+  "shared.errLoadContainer": "Freigegebener Container konnte nicht geladen werden."
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1410,5 +1410,14 @@
   "bulk.selectedCount.one": "{count} selected",
   "bulk.selectedCount.other": "{count} selected",
   "collection.sort.scanned-desc": "Scanned (Newest First)",
-  "collection.sort.scanned-asc": "Scanned (Oldest First)"
+  "collection.sort.scanned-asc": "Scanned (Oldest First)",
+  "loc.prev": "← Prev",
+  "loc.allowStacking": "Stack duplicates in one pocket",
+  "loc.allowStackingHint": "Copies of the same card share a pocket and show a count, so a page holds that many more distinct cards.",
+  "loc.cardsStoredLabel": "Cards stored",
+  "loc.slotsUsedLabel": "Slots used",
+  "compartment.stackedHere": "{count} copies stacked in this pocket",
+  "settings.linkContainer": "Container Share Links",
+  "settings.copied.container": "Copied public container link to clipboard.",
+  "shared.errLoadContainer": "Failed to load shared container."
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1435,5 +1435,14 @@
   "wizard.nothingToMove": "No hay cartas que mover.",
   "wizard.page": "Página",
   "wizard.selectAll": "Seleccionar todo",
-  "wizard.slot": "Hueco {slot}"
+  "wizard.slot": "Hueco {slot}",
+  "loc.prev": "← Ant.",
+  "loc.allowStacking": "Apilar duplicados en un bolsillo",
+  "loc.allowStackingHint": "Las copias de la misma carta comparten un bolsillo y muestran un contador, así que la página cabe más cartas distintas.",
+  "loc.cardsStoredLabel": "Cartas guardadas",
+  "loc.slotsUsedLabel": "Espacios usados",
+  "compartment.stackedHere": "{count} copias apiladas en este bolsillo",
+  "settings.linkContainer": "Enlaces para compartir contenedores",
+  "settings.copied.container": "Enlace público del contenedor copiado al portapapeles.",
+  "shared.errLoadContainer": "No se pudo cargar el contenedor compartido."
 }

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1435,5 +1435,14 @@
   "wizard.nothingToMove": "Aucune carte à déplacer.",
   "wizard.page": "Page",
   "wizard.selectAll": "Tout sélectionner",
-  "wizard.slot": "Emplacement {slot}"
+  "wizard.slot": "Emplacement {slot}",
+  "loc.prev": "← Préc.",
+  "loc.allowStacking": "Empiler les doublons dans une même pochette",
+  "loc.allowStackingHint": "Les exemplaires d’une même carte partagent une pochette et affichent un compteur, donc la page contient davantage de cartes différentes.",
+  "loc.cardsStoredLabel": "Cartes rangées",
+  "loc.slotsUsedLabel": "Emplacements utilisés",
+  "compartment.stackedHere": "{count} exemplaires empilés dans cette pochette",
+  "settings.linkContainer": "Liens de partage de conteneur",
+  "settings.copied.container": "Lien public du conteneur copié dans le presse-papiers.",
+  "shared.errLoadContainer": "Impossible de charger le conteneur partagé."
 }

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1435,5 +1435,14 @@
   "wizard.nothingToMove": "Nessuna carta da spostare.",
   "wizard.page": "Pagina",
   "wizard.selectAll": "Seleziona tutto",
-  "wizard.slot": "Posto {slot}"
+  "wizard.slot": "Posto {slot}",
+  "loc.prev": "← Prec.",
+  "loc.allowStacking": "Impila i duplicati in una tasca",
+  "loc.allowStackingHint": "Le copie della stessa carta condividono una tasca e mostrano un contatore, così la pagina contiene più carte diverse.",
+  "loc.cardsStoredLabel": "Carte conservate",
+  "loc.slotsUsedLabel": "Spazi occupati",
+  "compartment.stackedHere": "{count} copie impilate in questa tasca",
+  "settings.linkContainer": "Link di condivisione contenitori",
+  "settings.copied.container": "Link pubblico del contenitore copiato negli appunti.",
+  "shared.errLoadContainer": "Impossibile caricare il contenitore condiviso."
 }

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -1385,5 +1385,14 @@
   "wizard.nothingToMove": "移動するカードはありません。",
   "wizard.page": "ページ",
   "wizard.selectAll": "すべて選択",
-  "wizard.slot": "スロット {slot}"
+  "wizard.slot": "スロット {slot}",
+  "loc.prev": "← 前へ",
+  "loc.allowStacking": "重複カードを1ポケットに重ねる",
+  "loc.allowStackingHint": "同じカードの複数枚が1つのポケットを共有し枚数を表示するため、1ページにより多くの異なるカードが入ります。",
+  "loc.cardsStoredLabel": "収納枚数",
+  "loc.slotsUsedLabel": "使用スロット",
+  "compartment.stackedHere": "このポケットに{count}枚重ねています",
+  "settings.linkContainer": "コンテナの共有リンク",
+  "settings.copied.container": "コンテナの公開リンクをクリップボードにコピーしました。",
+  "shared.errLoadContainer": "共有コンテナを読み込めませんでした。"
 }

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -1385,5 +1385,14 @@
   "wizard.nothingToMove": "옮길 카드가 없습니다.",
   "wizard.page": "페이지",
   "wizard.selectAll": "전체 선택",
-  "wizard.slot": "{slot}번 칸"
+  "wizard.slot": "{slot}번 칸",
+  "loc.prev": "← 이전",
+  "loc.allowStacking": "중복 카드를 한 포켓에 겹치기",
+  "loc.allowStackingHint": "같은 카드의 여러 장이 한 포켓을 공유하고 장수를 표시하므로, 한 페이지에 더 많은 다른 카드를 넣을 수 있습니다.",
+  "loc.cardsStoredLabel": "보관된 카드",
+  "loc.slotsUsedLabel": "사용된 슬롯",
+  "compartment.stackedHere": "이 포켓에 {count}장 겹쳐져 있습니다",
+  "settings.linkContainer": "보관함 공유 링크",
+  "settings.copied.container": "보관함 공개 링크를 클립보드에 복사했습니다.",
+  "shared.errLoadContainer": "공유된 보관함을 불러오지 못했습니다."
 }

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1435,5 +1435,14 @@
   "wizard.nothingToMove": "Nenhuma carta para mover.",
   "wizard.page": "Página",
   "wizard.selectAll": "Selecionar tudo",
-  "wizard.slot": "Espaço {slot}"
+  "wizard.slot": "Espaço {slot}",
+  "loc.prev": "← Ant.",
+  "loc.allowStacking": "Empilhar duplicatas em um bolso",
+  "loc.allowStackingHint": "Cópias da mesma carta dividem um bolso e mostram a contagem, então a página cabe mais cartas diferentes.",
+  "loc.cardsStoredLabel": "Cartas guardadas",
+  "loc.slotsUsedLabel": "Espaços usados",
+  "compartment.stackedHere": "{count} cópias empilhadas neste bolso",
+  "settings.linkContainer": "Links de compartilhamento de contêiner",
+  "settings.copied.container": "Link público do contêiner copiado para a área de transferência.",
+  "shared.errLoadContainer": "Falha ao carregar o contêiner compartilhado."
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1460,5 +1460,14 @@
   "wizard.nothingToMove": "Нет карт для перемещения.",
   "wizard.page": "Страница",
   "wizard.selectAll": "Выбрать все",
-  "wizard.slot": "Ячейка {slot}"
+  "wizard.slot": "Ячейка {slot}",
+  "loc.prev": "← Назад",
+  "loc.allowStacking": "Складывать дубликаты в один карман",
+  "loc.allowStackingHint": "Копии одной карты занимают один карман и показывают количество, поэтому на странице помещается больше разных карт.",
+  "loc.cardsStoredLabel": "Карт хранится",
+  "loc.slotsUsedLabel": "Занято мест",
+  "compartment.stackedHere": "{count} копий в этом кармане",
+  "settings.linkContainer": "Ссылки на контейнеры",
+  "settings.copied.container": "Публичная ссылка на контейнер скопирована в буфер обмена.",
+  "shared.errLoadContainer": "Не удалось загрузить общий контейнер."
 }

--- a/frontend/src/locales/zh-Hans.json
+++ b/frontend/src/locales/zh-Hans.json
@@ -1385,5 +1385,14 @@
   "wizard.nothingToMove": "没有需要移动的卡牌。",
   "wizard.page": "页",
   "wizard.selectAll": "全选",
-  "wizard.slot": "第 {slot} 位"
+  "wizard.slot": "第 {slot} 位",
+  "loc.prev": "← 上一页",
+  "loc.allowStacking": "将重复卡叠放在同一卡位",
+  "loc.allowStackingHint": "同一张卡的多份共用一个卡位并显示数量，因此一页可以放更多不同的卡。",
+  "loc.cardsStoredLabel": "已收纳卡片",
+  "loc.slotsUsedLabel": "已用卡位",
+  "compartment.stackedHere": "此卡位叠放了 {count} 张",
+  "settings.linkContainer": "收纳容器分享链接",
+  "settings.copied.container": "已将容器公开链接复制到剪贴板。",
+  "shared.errLoadContainer": "无法加载共享容器。"
 }

--- a/frontend/src/locales/zh-Hant.json
+++ b/frontend/src/locales/zh-Hant.json
@@ -1385,5 +1385,14 @@
   "wizard.nothingToMove": "沒有需要移動的卡牌。",
   "wizard.page": "頁",
   "wizard.selectAll": "全選",
-  "wizard.slot": "第 {slot} 格"
+  "wizard.slot": "第 {slot} 格",
+  "loc.prev": "← 上一頁",
+  "loc.allowStacking": "將重複卡疊放在同一卡位",
+  "loc.allowStackingHint": "同一張卡的多份共用一個卡位並顯示數量，因此一頁可以放更多不同的卡。",
+  "loc.cardsStoredLabel": "已收納卡片",
+  "loc.slotsUsedLabel": "已用卡位",
+  "compartment.stackedHere": "此卡位疊放了 {count} 張",
+  "settings.linkContainer": "收納容器分享連結",
+  "settings.copied.container": "已將容器公開連結複製到剪貼板。",
+  "shared.errLoadContainer": "無法載入共享容器。"
 }

--- a/frontend/src/utils/cardOptions.js
+++ b/frontend/src/utils/cardOptions.js
@@ -36,6 +36,15 @@ export const GRADES = [10, 9.5, 9, 8.5, 8, 7.5, 7, 6.5, 6, 5.5, 5, 4, 3, 2, 1];
 // UI spots that branch on it share one definition.
 export const isBinderType = (type) => type === 'Binder' || type === 'Toploader Binder';
 
+// Which two pages face each other on the desktop spread holding a given page.
+// A binder opens on page 1 alone against the inside cover, so pages pair up 2-3,
+// 4-5 and so on — and a binder with an even page count ends on a page sitting
+// alone on the left. leftIdx is -1 on the opening spread: nothing faces page 1.
+export function binderSpread(pageIndex) {
+  const spread = Math.floor((Math.max(0, pageIndex) + 1) / 2);
+  return { spread, leftIdx: spread * 2 - 1, rightIdx: spread * 2 };
+}
+
 // Container type labels are translated, but the type itself is the English string
 // stored in the database, so the two are paired here rather than in each screen
 // that renders one. The label is t(`container.type.${containerTypeKey(type)}`);


### PR DESCRIPTION
## Summary

Three storage changes, plus a cosmetic follow-up on #38.

### Stacking duplicates in one pocket (`locations.allow_stacking`, off by default)

One physical card is one row and one slot — which is what a binder is, until the owner sleeves four copies of the same card into one pocket, and then a nine-pocket page holds nine cards instead of the twelve actually in it.

With the container's new **Stack duplicates in one pocket** setting on, copies of the same printing of the same card in the same language share a slot:

- the pocket shows a `×N` badge;
- occupancy counts slots used, not cards held — `loadCompartments`, the manual-place capacity check, the auto-file check and the container summary all agree on that;
- auto-filing sends a duplicate to its twin's slot instead of claiming a new one (and batch filing does not charge it a slot);
- dropping a copy onto its twin joins that pocket instead of trading the two rows, a swap of two identical cards being a no-op nobody can see.

Condition is deliberately not part of the key, matching how the collection view's own "stack duplicates" groups. With the setting off, everything counts exactly as before.

### Binder spreads open like a binder

Pages were paired 1-2, 3-4 — so page 1 faced page 2, which no binder does: page 1 is a single leaf against the inside cover, its back is page 2, and the pairs run 2-3, 4-5. Pages now pair that way, which also means a binder with an even page count ends on a page sitting alone on the left. Both empty halves keep their side of the spine, so the page that is there does not slide across it.

### A container can be shared as itself

A share link with `?container=<id>` renders that one binder or box through the same `CompartmentView` its owner sees — pockets and page spreads, or the box coverflow — instead of collapsing it into a flat card list. Read-only: no callbacks are passed, so none of the rename, capacity, lock or arrange controls render.

Gated on the existing **share locations** toggle rather than a new setting, because where a card is stored is exactly what the view exposes. The links live in Settings beside the collection, trade and wishlist ones and appear only while that toggle is on.

### Also

- `MultiSelectDropdown` (from #38) now uses the app's existing translation keys instead of English literals, `--bg-secondary` instead of a `--bg-elevated` that does not exist (so the popover follows the light and LCARS themes), and a plain accent-coloured checkbox instead of a hidden input behind a styled span that no keyboard or screen reader could reach.
- The container settings modal no longer reads "There are {count} cards currently stored in this container." with the placeholder unfilled — that row puts the count in the value beside the label, so it now uses a label-shaped key.

## Testing

- New `backend/test/binderstacking.test.js`: occupancy counts slots not cards, auto-filing stacks a duplicate onto its twin and only a duplicate, a manual drop onto a twin stacks instead of swapping, and with stacking off occupancy is the card count again.
- Full backend suite (31 unit files + 5 e2e suites, 32 e2e cases) and the frontend suite including `check:locales` pass; all ten locales carry the new keys.
- Checked in the running app against a scratch copy of a real database: multi-select filters union correctly and clear back to everything; a page with four copies of one card in a pocket shows `×3`/`×N` and reports 9/9 slots rather than overfull; toggling the setting off splits the pocket again and the summary returns to a card count; the binder opens on page 1 alone, then 2-3, then page 4 alone with Next disabled; `?container=` renders the binder as a spread and a box as its coverflow, and 404s while share-locations is off.