### PR TITLE
fix: OIDC/SSO breaking issue: Need to select between client_secret_post or client_secret_basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ All optional.
 | `OIDC_PROVIDER_NAME` | `Single Sign-On` | Display name shown on the login button (e.g. `Authelia`, `Authentik`, `Keycloak`). |
 | `OIDC_USER_CLAIM` | `preferred_username` | Identity claim to map to the Bindarr username. |
 | `OIDC_AUTO_PROVISION` | `true` | Automatically create a Bindarr member account on first successful SSO login. |
+| `OIDC_TOKEN_ENDPOINT_AUTH_METHOD` | `client_secret_basic` | Token endpoint client authentication method. Set to client_secret_basic or client_secret_post. |
 | `TRUST_PROXY` | — | Number of proxy hops (usually `1`) when a reverse proxy terminates TLS, so rate limiting sees the real client IP. |
 | `CV_MODEL_DIR` | `/app/database/models` in the image | Where the scan models and catalogs live. Must be on persistent storage, or an image update discards every catalog you built. |
 | `CV_SCAN_GAP` | `0.10` | How far a match must stand above its runner-ups before it counts as an answer rather than "this card is not in the catalog". Lower accepts more guesses. |

--- a/backend/src/utils/oidc.js
+++ b/backend/src/utils/oidc.js
@@ -62,6 +62,27 @@ function resolveRedirectUri(req) {
   return 'http://localhost:3001/api/auth/oidc/callback';
 }
 
+function getTokenEndpointAuthMethod() {
+  const method = (
+    process.env.OIDC_TOKEN_ENDPOINT_AUTH_METHOD || 'client_secret_basic'
+  ).trim();
+
+  const supported = [
+    'client_secret_basic',
+    'client_secret_post',
+    'none'
+  ];
+
+  if (!supported.includes(method)) {
+    throw new Error(
+      `Unsupported OIDC_TOKEN_ENDPOINT_AUTH_METHOD: ${method}. ` +
+      `Supported values: ${supported.join(', ')}`
+    );
+  }
+
+  return method;
+}
+
 /**
  * Fetch and cache OpenID Connect Discovery document (.well-known/openid-configuration).
  */
@@ -208,28 +229,48 @@ async function exchangeCode({ code, stateToken, req }) {
   const discovery = await getDiscovery();
   const clientId = getClientId();
   const clientSecret = getClientSecret();
+  const authMethod = getTokenEndpointAuthMethod();
   const redirectUri = stateData.ru || resolveRedirectUri(req);
+
+  if (!clientId) {
+    throw new Error('OIDC_CLIENT_ID is not configured');
+  }
+
+  if (
+    ['client_secret_basic', 'client_secret_post'].includes(authMethod) &&
+    !clientSecret
+  ) {
+    throw new Error(
+      `OIDC_CLIENT_SECRET is required when using ${authMethod}`
+    );
+  }
 
   const params = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
     redirect_uri: redirectUri,
-    client_id: clientId,
     code_verifier: stateData.cv
   });
-
-  if (clientSecret) {
-    params.set('client_secret', clientSecret);
-  }
 
   const headers = {
     'Content-Type': 'application/x-www-form-urlencoded',
     Accept: 'application/json'
   };
 
-  // Also include Authorization header if secret is present for providers requiring HTTP Basic auth
-  if (clientSecret) {
-    headers['Authorization'] = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+  switch (authMethod) {
+    case 'client_secret_basic':
+      headers.Authorization =
+        `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+      break;
+
+    case 'client_secret_post':
+      params.set('client_id', clientId);
+      params.set('client_secret', clientSecret);
+      break;
+
+    case 'none':
+      params.set('client_id', clientId);
+      break;
   }
 
   const tokenRes = await fetch(discovery.token_endpoint, {
@@ -315,6 +356,7 @@ module.exports = {
   isAutoProvisionEnabled,
   getDefaultRole,
   getUserClaimName,
+  getTokenEndpointAuthMethod,
   getDiscovery,
   generatePkce,
   createStateToken,


### PR DESCRIPTION
**Issue**
The code currently attempts to use both client_secret_basic and client_secret_post headers. This causes most OIDC systems to reject the login request, resulting in a 400 error.

**Fix**
- Added a new env variable `OIDC_TOKEN_ENDPOINT_AUTH_METHOD` to select between post or basic mode.
- Modified the auth code to use only the headers needed according to config.
- Updated readme.

**Testing**
Tested using a self-host Authentik server and found to function as intended:
- Able to log in using SSO.
- If SSO user does not have an account - a new one is created.
- If SSO user already has an account (i.e. same username) then it authenticates as that account (this is actually a security issue, which I will raise as its own issue since the 'admin' account is always created and therefore one could feasibly escalate if they are able to change their SSO username somehow - but this fix is not attempting to address that hole)