### PR TITLE
fix(admin): stop /api/admin/catalogs scanning card_cache once per set

### DIFF
--- a/backend/src/catalog.js
+++ b/backend/src/catalog.js
@@ -122,22 +122,34 @@ async function newSetCount(game, lang = 'English') {
     // Scoped to the language, or a Spanish catalog would be measured against the
     // ENGLISH cache and report whatever English happens to be missing: measured
     // 98 for both mtg/English and mtg/Spanish while the Spanish cache held 1,205
-    // cards against English's 103,656. Invisible today only because no local MTG
-    // catalog exists to ask, which is exactly how it would have shipped.
-    const row = await db.get(
-      `SELECT COUNT(*) n FROM sets s
-        WHERE s.game = ? AND COALESCE(s.total, 0) > 0
-          AND LOWER(CASE WHEN s.id LIKE 'mtg-%' THEN SUBSTR(s.id, 5) WHEN s.id LIKE 'lorcana-%' THEN SUBSTR(s.id, 9) ELSE s.id END) NOT IN (
-            SELECT set_id FROM set_data_gaps WHERE game = s.game AND language = ?
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM card_cache c
-             WHERE c.game = s.game AND c.language = ?
-               AND (LOWER(c.set_id) = LOWER(s.id) OR LOWER(c.set_id) = LOWER(CASE WHEN s.id LIKE 'mtg-%' THEN SUBSTR(s.id, 5) WHEN s.id LIKE 'lorcana-%' THEN SUBSTR(s.id, 9) ELSE s.id END))
-          )`,
-      [game, lang, lang]
+    // cards against English's 103,656.
+    //
+    // Compared in JS, exactly like the Pokemon branch above, and for the same
+    // reason it has to be: the id namespaces differ, so the test needs LOWER() on
+    // both sides and an OR between the prefixed and the bare form. Neither side can
+    // use idx_card_cache_set_num, so as a correlated NOT EXISTS this re-scanned the
+    // WHOLE of card_cache once per set. Measured against 1,047 MTG sets and 126k
+    // cached rows: 9.6s with 50 sets uncached, 28s with 400 — on the single sqlite3
+    // connection, so every other request in the app queues behind it. That is why
+    // one Admin page load 504'd and took Users and the dashboard down with it (#49).
+    // It only ever ran once an MTG catalog was built, because list() asks for
+    // newSets only when `built` — which is why deleting the milo-mtg-local files
+    // "fixed" it. One pass over each table instead: same answer, ~80ms.
+    const cached = new Set((await db.all(
+      `SELECT DISTINCT LOWER(set_id) sid FROM card_cache WHERE game = ? AND language = ?`,
+      [game, lang]
+    )).map(r => r.sid));
+    const rows = await db.all(
+      `SELECT id FROM sets WHERE game = ? AND COALESCE(total, 0) > 0`, [game]
     );
-    return row ? row.n : null;
+    // The `sets` table prefixes ids ("mtg-fdn", "lorcana-tfc") while card_cache
+    // holds the bare code ("fdn"). Both forms are checked, which is what the OR in
+    // the old query did — dropping either one reports every set as new.
+    const bare = (id) => String(id).toLowerCase().replace(/^(?:mtg|lorcana)-/, '');
+    return rows.filter(r =>
+      !gaps.has(bare(r.id))
+      && !cached.has(String(r.id).toLowerCase())
+      && !cached.has(bare(r.id))).length;
   } catch {
     return null;
   }
@@ -561,4 +573,4 @@ function start(game, lang = 'English', opts = {}) {
 let last = null;
 const lastResult = () => last;
 
-module.exports = { list, listLanguages, setCounts, keptFromPrev, start, stop, state, lastResult, binPath, metaPath, GAMES };
+module.exports = { list, listLanguages, setCounts, newSetCount, keptFromPrev, start, stop, state, lastResult, binPath, metaPath, GAMES };

--- a/backend/test/newsetcount.test.js
+++ b/backend/test/newsetcount.test.js
@@ -1,0 +1,113 @@
+// newSetCount is the number behind the Admin panel's "N sets not downloaded yet"
+// warning, and it used to be a correlated NOT EXISTS over card_cache: one full
+// scan of the table per set in `sets`, because LOWER() on both sides of the
+// comparison makes idx_card_cache_set_num unusable. With an MTG catalog built
+// (1,047 sets, 126k cached rows) that measured 9.6s with 50 sets uncached and 28s
+// with 400 — on the app's single sqlite3 connection, so every other request
+// queued behind it and the Admin page 504'd, taking Users and the dashboard with
+// it. That is #49.
+//
+// Two things are checked here. The counting rules, which are fiddly enough to
+// break silently while still returning a plausible number: the `sets` table
+// prefixes ids ("mtg-fdn") and card_cache holds the bare code ("fdn"), the
+// comparison is case-insensitive, sets with no printed total do not count, and
+// sets already known to have no upstream data (set_data_gaps) are excluded. And
+// the cost, with a budget generous enough not to be flaky on a slow runner but
+// far below the seconds the old shape took.
+//
+// No framework — plain node + assert. Run: `node test/newsetcount.test.js`
+const assert = require('assert');
+const os = require('os');
+const path = require('path');
+
+process.env.DB_PATH = path.join(os.tmpdir(), `bindarr-newsetcount-${process.pid}.db`);
+const db = require('../src/db');
+const { newSetCount } = require('../src/catalog');
+
+// Big enough that a per-set scan of card_cache is unmistakably slower than one
+// pass, small enough to seed in a second. The real install is 1,047 x 104k.
+const NSETS = 300;
+const UNCACHED = 60;          // sets with no cards at all -> the answer
+const GAPPED = 5;             // of those, known-empty upstream -> excluded
+const CARDS = 20000;
+
+async function main() {
+  await db.initDb();
+
+  const codes = Array.from({ length: NSETS }, (_, i) => `s${i.toString(36)}`);
+  const covered = codes.slice(0, NSETS - UNCACHED);
+
+  await db.withTransaction(async () => {
+    for (const c of codes) {
+      // Mixed case in the set table, because Scryfall codes are not all lower and
+      // the comparison has to survive that.
+      await db.run(`INSERT INTO sets (id, name, total, game) VALUES (?, ?, ?, ?)`,
+        [`mtg-${c.toUpperCase()}`, `Set ${c}`, 250, 'mtg']);
+    }
+    // A set with no printed total is not a set anyone can download; it must not
+    // be counted as missing.
+    await db.run(`INSERT INTO sets (id, name, total, game) VALUES (?, ?, ?, ?)`,
+      ['mtg-empty', 'No total', 0, 'mtg']);
+
+    for (let i = 0; i < CARDS; i++) {
+      await db.run(
+        `INSERT INTO card_cache (id, name, set_id, number, game, language) VALUES (?, ?, ?, ?, ?, ?)`,
+        [`mtg-c${i}`, `Card ${i}`, covered[i % covered.length], String(i % 250), 'mtg', 'English']
+      );
+    }
+    // Another game and another language in the same table: neither may be counted,
+    // and both are rows the old query scanned on every single set.
+    for (let i = 0; i < 2000; i++) {
+      await db.run(
+        `INSERT INTO card_cache (id, name, set_id, number, game, language) VALUES (?, ?, ?, ?, ?, ?)`,
+        [`tcgdex-c${i}`, `Card ${i}`, `A${i % 50}`, String(i), 'pokemon', 'English']
+      );
+    }
+    for (const c of codes.slice(NSETS - UNCACHED)) {
+      await db.run(
+        `INSERT INTO card_cache (id, name, set_id, number, game, language) VALUES (?, ?, ?, ?, ?, ?)`,
+        [`mtg-es-${c}`, `Carta ${c}`, c, '1', 'mtg', 'Spanish']
+      );
+    }
+  });
+
+  // 1. The count itself: every set with a printed total and no English cards.
+  const t0 = Date.now();
+  assert.strictEqual(await newSetCount('mtg', 'English'), UNCACHED,
+    'a set with no cards cached in this language is a set not downloaded yet');
+  const ms = Date.now() - t0;
+
+  // 2. Cost, which is the actual regression guard: every assertion here passes
+  //    against the old query too, because the rewrite changed only how the answer
+  //    is computed. On this fixture the old shape measured 1,305ms and the new one
+  //    12ms. 500ms sits between them with 40x of slack for a slow runner, and a
+  //    real install is 3x the sets and 6x the rows, where the gap is 9.6s vs 80ms.
+  assert.ok(ms < 500, `newSetCount took ${ms}ms — the per-set scan of card_cache is back`);
+
+  // 3. Spanish has one card in each of the sets English is missing, and nothing in
+  //    the rest. Scoping to the language is the whole reason this takes a `lang`:
+  //    measuring Spanish against the English cache reported English's gaps.
+  assert.strictEqual(await newSetCount('mtg', 'Spanish'), NSETS - UNCACHED,
+    'each language is measured against its own cached cards');
+
+  // 4. Sets a build already found to have no data upstream are not "not downloaded
+  //    yet" — they are sets that cannot be downloaded, and counting them told the
+  //    user to rebuild forever. Stored lower case; the set table has them upper.
+  await db.withTransaction(async () => {
+    for (const c of codes.slice(NSETS - UNCACHED, NSETS - UNCACHED + GAPPED)) {
+      await db.run(
+        `INSERT INTO set_data_gaps (game, language, set_id) VALUES (?, ?, ?)`,
+        ['mtg', 'English', c]
+      );
+    }
+  });
+  assert.strictEqual(await newSetCount('mtg', 'English'), UNCACHED - GAPPED,
+    'a set with no upstream data must not be reported as missing');
+
+  // 5. A game with nothing in either table has nothing missing, not everything.
+  assert.strictEqual(await newSetCount('lorcana', 'English'), 0);
+
+  console.log(`newsetcount.test.js: all 5 assertions passed (count took ${ms}ms)`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Fixes #49.

## Cause

`newSetCount()` in `backend/src/catalog.js` has two branches. The Pokémon one reads the distinct cached set ids once and compares in JS. The other one — MTG and Lorcana — asked the same question as a correlated `NOT EXISTS` over `card_cache`, with `LOWER()` on both sides and an `OR` between the prefixed (`mtg-fdn`) and bare (`fdn`) id forms.

Nothing in that predicate can use `idx_card_cache_set_num`, so SQLite re-scans the whole of `card_cache` once per row in `sets`:

```
EXPLAIN QUERY PLAN
  SCAN s | CORRELATED LIST SUBQUERY 1 | SCAN set_data_gaps
        | CORRELATED SCALAR SUBQUERY 2 | SCAN c
```

The reporter's install is 1,047 MTG sets against 104,544 MTG rows plus 21,844 Pokémon rows. Measured on a synthetic database of exactly that shape:

| sets with nothing cached | before | after |
|---|---|---|
| 0 | 762 ms | 97 ms |
| 50 | 9,645 ms | 80 ms |
| 150 | 13,001 ms | 55 ms |
| 400 | 28,144 ms | 46 ms |

That is on a local NVMe desktop; an Unraid array is slower again.

## Why it took the whole app down

`backend/src/db.js` opens one `sqlite3.Database`, so statements serialize on it. While that scan runs, every other query in the app is queued behind it — which is why the report is not just "catalogs is slow" but Users stuck loading and the dashboard erroring too.

## Why it started when it did

`list()` asks for `newSets` only when a catalog is `built`, and `built` is `fs.existsSync(metaPath(game, lang))` — `data/models/milo-mtg-local.json`. So the query never ran until the MTG scan catalog was built, and stopped running when those files were deleted. That matches the reporter's own finding exactly.

## Fix

Use the shape the Pokémon branch already uses: one `SELECT DISTINCT LOWER(set_id)` over `card_cache` for the language, one read of the set list, compare in JS. O(n+m) instead of O(n·m).

## Behaviour change

One, deliberate: `set_data_gaps` ids are now matched case-insensitively. The old SQL lowercased only its left-hand side and compared against the raw stored value. The Pokémon branch already lowercases both. This can only exclude more known-empty sets, never fewer.

## Verification

- New `backend/test/newsetcount.test.js`. Its correctness assertions pass against **both** implementations, which is the point — the rewrite changes only how the answer is reached. The regression guard is the cost assertion: on the test's own fixture (300 sets, 22k rows) the old query measures 1,305 ms and the new one 11–12 ms, and the test budget is 500 ms. Reverting `catalog.js` makes the test fail.
- `node test/run.js` — 37/37 files pass (36/36 before this branch).
- `node test/e2e/run.js` — 5/5 suites, 32/32 cases.

## Not in this PR

- An index on `card_cache(game, language, set_id)`. The remaining full scan is ~50–90 ms and nothing else needs it yet.
- Splitting the sqlite3 connection, or a slow-query guard on admin routes. Real hardening, but the reason one slow query can starve the app is a separate issue from this query being slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)