### PR TITLE
fix(oidc): do not link an IdP identity to a local account by username

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ All optional.
 | `OIDC_PROVIDER_NAME` | `Single Sign-On` | Display name shown on the login button (e.g. `Authelia`, `Authentik`, `Keycloak`). |
 | `OIDC_USER_CLAIM` | `preferred_username` | Identity claim to map to the Bindarr username. |
 | `OIDC_AUTO_PROVISION` | `true` | Automatically create a Bindarr member account on first successful SSO login. |
+| `OIDC_ALLOW_USERNAME_LINK` | `false` | Let an SSO identity attach itself to an **existing** Bindarr account that has the same username. Needed to move accounts created before SSO onto it. **Only turn this on if your users cannot choose their own username at the identity provider** — if they can, someone setting theirs to `admin` takes the owner account on their first login. With it off, an SSO login whose username is already taken is refused rather than silently given a second, empty account. |
 | `OIDC_TOKEN_ENDPOINT_AUTH_METHOD` | `client_secret_basic` | Token endpoint client authentication method. Set to client_secret_basic or client_secret_post. |
 | `TRUST_PROXY` | — | Number of proxy hops (usually `1`) when a reverse proxy terminates TLS, so rate limiting sees the real client IP. |
 | `CV_MODEL_DIR` | `/app/database/models` in the image | Where the scan models and catalogs live. Must be on persistent storage, or an image update discards every catalog you built. |

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -76,11 +76,36 @@ router.get('/oidc/callback', authLimiter, async (req, res) => {
     // 1. Match by existing oidc_sub
     let user = await db.get(`SELECT * FROM users WHERE oidc_sub = ?`, [sub]);
 
-    // 2. Fallback: match by username and link oidc_sub
+    // 2. Fallback: attach this identity to an existing account with the same
+    //    username — only when the operator has said their IdP's usernames can be
+    //    trusted for it. See isUsernameLinkEnabled: with it on by default, anyone
+    //    who could set their own preferred_username to "admin" at the IdP could
+    //    take the Bindarr owner account by signing in once.
     if (!user) {
       const existingUser = await db.get(`SELECT * FROM users WHERE username = ?`, [username]);
+      // Linking off and the name is taken: say so, rather than falling through to
+      // auto-provisioning, which would quietly hand them a brand new "<name>-1"
+      // account with an empty collection and leave them convinced the upgrade ate
+      // their cards.
+      if (existingUser && !oidc.isUsernameLinkEnabled()) {
+        console.warn(`OIDC: "${username}" already exists locally and OIDC_ALLOW_USERNAME_LINK is off — not linking.`);
+        return frontendRedirect({
+          oidc_error: 'A Bindarr account with this username already exists. An administrator must set OIDC_ALLOW_USERNAME_LINK=true to attach single sign-on to it.'
+        });
+      }
       if (existingUser) {
+        // An account already bound to a DIFFERENT IdP identity is never re-bound.
+        // Two subjects claiming one username is the collision this whole flag is
+        // about, and silently moving the account to whoever logged in last is the
+        // worst of the available answers.
+        if (existingUser.oidc_sub && existingUser.oidc_sub !== sub) {
+          console.warn(`OIDC: refusing to relink "${username}" — already bound to another identity.`);
+          return frontendRedirect({
+            oidc_error: 'That username is already linked to a different single sign-on identity. Ask an administrator.'
+          });
+        }
         await db.run(`UPDATE users SET oidc_sub = ? WHERE id = ?`, [sub, existingUser.id]);
+        console.log(`OIDC: linked identity to existing account "${username}" (OIDC_ALLOW_USERNAME_LINK).`);
         user = await db.get(`SELECT * FROM users WHERE id = ?`, [existingUser.id]);
       }
     }

--- a/backend/src/utils/oidc.js
+++ b/backend/src/utils/oidc.js
@@ -22,6 +22,26 @@ function isAutoProvisionEnabled() {
   return true;
 }
 
+// Whether an IdP identity may attach itself to a Bindarr account that already
+// exists, purely because the two share a username.
+//
+// Off unless the operator turns it on, and that is the whole point. The username
+// comes from a claim the IdP sends (OIDC_USER_CLAIM, preferred_username by
+// default) and extractUserIdentity lower-cases it, while the Bindarr owner
+// account is always created as "admin". So on any IdP where a person can choose
+// or edit their own username — self-registration, or a profile page that lets
+// them — setting it to "admin" and signing in once used to bind their identity
+// to the owner account and log them straight in as it. No password involved.
+//
+// It cannot simply be deleted: an install that predates SSO has real accounts
+// with real collections behind them, and linking by username is how those
+// accounts keep working. So it stays available, and the operator says whether
+// their IdP's usernames are trustworthy enough for it — which is a fact only
+// they have.
+function isUsernameLinkEnabled() {
+  return process.env.OIDC_ALLOW_USERNAME_LINK === 'true' || process.env.OIDC_ALLOW_USERNAME_LINK === '1';
+}
+
 function getDefaultRole() {
   return process.env.OIDC_DEFAULT_ROLE === 'admin' ? 'admin' : 'member';
 }
@@ -356,6 +376,7 @@ module.exports = {
   isAutoProvisionEnabled,
   getDefaultRole,
   getUserClaimName,
+  isUsernameLinkEnabled,
   getTokenEndpointAuthMethod,
   getDiscovery,
   generatePkce,

--- a/backend/test/e2e/oidc.test.js
+++ b/backend/test/e2e/oidc.test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const { spawn } = require('child_process');
 
 const tmpDb = path.join(os.tmpdir(), `bindarr-oidc-test-${process.pid}.db`);
+const linkDb = path.join(os.tmpdir(), `bindarr-oidc-link-${process.pid}.db`);
 const projectRoot = path.join(__dirname, '../../../');
 
 async function waitForServer(url) {
@@ -185,6 +186,51 @@ async function runTests() {
     assert(badRedirect.includes('oidc_error='), 'invalid state must redirect with oidc_error');
     console.log('PASS: F7-TC7');
 
+    // F7-TC8: a NEW identity claiming an EXISTING account's username is refused.
+    //
+    // This is the account-takeover path. The owner account is always called
+    // "admin", extractUserIdentity lower-cases whatever the IdP sends, and on any
+    // IdP where a person can pick their own preferred_username, picking "admin"
+    // used to bind their identity to the owner account and log them in as it --
+    // no password anywhere in the flow. OIDC_ALLOW_USERNAME_LINK is unset here,
+    // which is the default, so it must be refused and the owner left alone.
+    mockUserClaims = {
+      sub: 'idp-sub-attacker',
+      preferred_username: 'admin',
+      email: 'attacker@example.invalid'
+    };
+    const loginRes4 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
+    const state4 = new URL(loginRes4.headers.get('location')).searchParams.get('state');
+    const callbackRes4 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-4&state=${encodeURIComponent(state4)}`, {
+      redirect: 'manual'
+    });
+    const takeoverRedirect = new URL(callbackRes4.headers.get('location'), base);
+    assert.strictEqual(takeoverRedirect.searchParams.get('oidc_token'), null,
+      'a username collision must not issue a session for the existing account');
+    assert(takeoverRedirect.searchParams.get('oidc_error'),
+      'a username collision must come back as an error');
+
+    // And the owner is untouched: its oidc_sub is still the identity that
+    // bootstrapped it, so the original owner can still sign in.
+    mockUserClaims = {
+      sub: 'idp-sub-777',
+      preferred_username: 'admin',
+      email: 'owner@pallet.org'
+    };
+    const loginRes5 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
+    const state5 = new URL(loginRes5.headers.get('location')).searchParams.get('state');
+    const callbackRes5 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-5&state=${encodeURIComponent(state5)}`, {
+      redirect: 'manual'
+    });
+    const ownerToken = new URL(callbackRes5.headers.get('location'), base).searchParams.get('oidc_token');
+    assert(ownerToken, 'the identity that bootstrapped the owner must still log in');
+    const ownerMe = await (await fetch(`${base}/api/auth/me`, {
+      headers: { 'Authorization': `Bearer ${ownerToken}` }
+    })).json();
+    assert.strictEqual(ownerMe.user.id, meData.user.id, 'must still be the same owner account');
+    assert.strictEqual(ownerMe.user.oidc_sub, 'idp-sub-777', 'the attacker must not have re-bound the owner');
+    console.log('PASS: F7-TC8');
+
   } finally {
     server.kill('SIGKILL');
     if (typeof idpServer.closeAllConnections === 'function') {
@@ -197,7 +243,140 @@ async function runTests() {
   }
 }
 
+// The other half of OIDC_ALLOW_USERNAME_LINK: with it ON, linking has to actually
+// work, because that is the only way an install that predates SSO gets its
+// existing accounts -- and their collections -- onto it. Its own server and its
+// own database, because it needs a local 'admin' account created the ordinary way
+// (password and all) rather than one bootstrapped by OIDC.
+async function runUsernameLinkTests() {
+  let mockUserClaims = {
+    sub: 'idp-sub-link',
+    preferred_username: 'admin',
+    email: 'owner@pallet.org'
+  };
+
+  const idpServer = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (url.pathname === '/.well-known/openid-configuration') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        issuer: `http://${req.headers.host}`,
+        authorization_endpoint: `http://${req.headers.host}/authorize`,
+        token_endpoint: `http://${req.headers.host}/token`,
+        userinfo_endpoint: `http://${req.headers.host}/userinfo`
+      }));
+      return;
+    }
+    if (url.pathname === '/token' && req.method === 'POST') {
+      req.on('data', () => {});
+      req.on('end', () => {
+        const payloadB64 = Buffer.from(JSON.stringify(mockUserClaims)).toString('base64url');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token: 'mock-access-token',
+          token_type: 'Bearer',
+          id_token: `eyJhbGciOiJub25lIn0.${payloadB64}.sig`,
+          expires_in: 3600
+        }));
+      });
+      return;
+    }
+    if (url.pathname === '/userinfo') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(mockUserClaims));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise(resolve => idpServer.listen(0, '127.0.0.1', resolve));
+  const idpIssuer = `http://127.0.0.1:${idpServer.address().port}`;
+
+  const port = '3020';
+  const base = `http://localhost:${port}`;
+  const server = spawn('node', [path.join(projectRoot, 'backend/src/server.js')], {
+    env: {
+      ...process.env,
+      // A pre-existing local account, exactly like an install upgrading into SSO.
+      DEFAULT_ADMIN_PASSWORD: 'test-admin-password',
+      PORT: port,
+      DB_PATH: linkDb,
+      HTTPS_PORT: '',
+      OIDC_ENABLED: 'true',
+      OIDC_PROVIDER_NAME: 'TestIdP',
+      OIDC_ISSUER_URL: idpIssuer,
+      OIDC_CLIENT_ID: 'bindarr-test-id',
+      OIDC_CLIENT_SECRET: 'bindarr-test-secret',
+      OIDC_AUTO_PROVISION: 'true',
+      OIDC_ALLOW_USERNAME_LINK: 'true'
+    }
+  });
+
+  const callback = async (code) => {
+    const loginRes = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
+    const state = new URL(loginRes.headers.get('location')).searchParams.get('state');
+    const res = await fetch(`${base}/api/auth/oidc/callback?code=${code}&state=${encodeURIComponent(state)}`, {
+      redirect: 'manual'
+    });
+    return new URL(res.headers.get('location'), base).searchParams;
+  };
+
+  try {
+    await waitForServer(`${base}/api/health`);
+
+    // F7-TC9: with the flag on, the IdP identity attaches to the existing local
+    // account rather than creating a second, empty one beside it.
+    const linked = await callback('link-code-1');
+    const linkToken = linked.get('oidc_token');
+    assert(linkToken, 'OIDC_ALLOW_USERNAME_LINK=true must let the identity link and log in');
+    const linkedMe = await (await fetch(`${base}/api/auth/me`, {
+      headers: { 'Authorization': `Bearer ${linkToken}` }
+    })).json();
+    assert.strictEqual(linkedMe.user.username, 'admin', 'must be the existing account, not a new one');
+    assert.strictEqual(linkedMe.user.oidc_sub, 'idp-sub-link');
+    console.log('PASS: F7-TC9');
+
+    // F7-TC10: a SECOND identity claiming the same username is still refused,
+    // even with linking on -- the account is already bound, and handing it to
+    // whoever logged in last is the takeover with an extra step.
+    mockUserClaims = {
+      sub: 'idp-sub-someone-else',
+      preferred_username: 'admin',
+      email: 'someone@example.invalid'
+    };
+    const second = await callback('link-code-2');
+    assert.strictEqual(second.get('oidc_token'), null,
+      'an account already bound to another identity must not be re-bound');
+    assert(second.get('oidc_error'), 'the refusal must come back as an error');
+
+    // The first identity still owns it.
+    mockUserClaims = {
+      sub: 'idp-sub-link',
+      preferred_username: 'admin',
+      email: 'owner@pallet.org'
+    };
+    const again = await callback('link-code-3');
+    const againMe = await (await fetch(`${base}/api/auth/me`, {
+      headers: { 'Authorization': `Bearer ${again.get('oidc_token')}` }
+    })).json();
+    assert.strictEqual(againMe.user.oidc_sub, 'idp-sub-link');
+    console.log('PASS: F7-TC10');
+
+  } finally {
+    server.kill('SIGKILL');
+    if (typeof idpServer.closeAllConnections === 'function') {
+      idpServer.closeAllConnections();
+    }
+    await new Promise(resolve => idpServer.close(resolve));
+    for (const suffix of ['', '-wal', '-shm']) {
+      try { fs.unlinkSync(linkDb + suffix); } catch { /* ignore */ }
+    }
+  }
+}
+
 runTests()
+  .then(runUsernameLinkTests)
   .then(() => setTimeout(() => process.exit(0), 500))
   .catch(err => {
     console.error('FAIL: oidc.test.js -', err.message);


### PR DESCRIPTION
Refs #43. Targets `feat/oidc-sso`, so it lands before #45 leaves draft.

## The hole

`backend/src/routes/auth.js` matched on `oidc_sub`, and when that missed it fell back to matching on username and bound the identity to whatever it found:

```js
// 2. Fallback: match by username and link oidc_sub
if (!user) {
  const existingUser = await db.get(`SELECT * FROM users WHERE username = ?`, [username]);
  if (existingUser) {
    await db.run(`UPDATE users SET oidc_sub = ? WHERE id = ?`, [sub, existingUser.id]);
    user = await db.get(`SELECT * FROM users WHERE id = ?`, [existingUser.id]);
  }
}
```

`username` comes from a claim the IdP sends (`OIDC_USER_CLAIM`, `preferred_username` by default), `extractUserIdentity` lower-cases it (`oidc.js:294`), and the Bindarr owner account is always created as `admin` (`auth.js:174`). So on any IdP where a person can set their own username — self-registration, or a profile page that lets them edit it — setting it to `admin` and signing in once bound their identity to the owner account and logged them straight in as it. No password anywhere in the flow.

@JGHCode flagged exactly this while testing #46 against Authentik and said it was out of scope for that PR. This is that fix.

## Why it is a flag and not a deletion

Linking by username is how an install that predates SSO gets its existing accounts — and the collections behind them — onto the IdP. Removing it would strand them. Whether the IdP's usernames can be trusted for that is a fact only the operator has, so it is now theirs to state:

| | |
|---|---|
| `OIDC_ALLOW_USERNAME_LINK` | default `false` |

## Behaviour

| Situation | Before | After |
|---|---|---|
| New sub, username matches an existing account, flag **off** | silently linked and logged in | refused, with a message naming the setting |
| New sub, username matches, flag **on** | linked | linked |
| New sub, username matches an account already bound to a **different** sub | re-bound to the new sub | refused |
| New sub, username free | auto-provisioned | unchanged |
| Known sub | logged in | unchanged |
| First user on an empty instance | bootstrapped as owner | unchanged |

The refusal in row 1 matters on its own. Without it the request falls through to auto-provisioning, whose collision loop would have handed the user a brand new `admin-1` account with an empty collection — and left them certain the upgrade had eaten their cards.

## Verification

Three new cases in `backend/test/e2e/oidc.test.js`, driving the real server against a mock IdP:

- **F7-TC8** — an attacker identity (`sub: idp-sub-attacker`, `preferred_username: admin`) against the default config must get `oidc_error` and no token, and the owner's `oidc_sub` must still be the one that bootstrapped it. Reverting `auth.js` makes this fail with the attacker holding a live session token for the owner account.
- **F7-TC9** — a second server, with `OIDC_ALLOW_USERNAME_LINK=true` and a local `admin` created the ordinary way, must link to that account rather than making a second one. This is the upgrade path.
- **F7-TC10** — with the flag still on, a second identity claiming `admin` is refused, and the first identity still owns the account.

`npm test` on this branch: 32/32 unit files, 6/6 e2e suites, 42/42 cases. `npm run lint` clean.

## Noted, not fixed here

`exchangeCode` does not verify the ID token signature or check `iss`/`aud`. That is defensible — the token comes straight from the token endpoint over TLS in the code flow, which OIDC Core §3.1.3.7 allows — but it is worth a look before this ships as a supported feature. Out of scope for a one-hole fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)