### PR TITLE
fix(oidc): validate the ID token instead of only decoding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ All optional.
 | `CORS_ORIGIN` | — | Extra allowed origins, comma-separated. Localhost and private-LAN origins are always allowed. |
 | `ALLOW_REGISTRATION` | unset | `true` allows self-registration. Unset means invite-only: admins create accounts. |
 | `OIDC_ENABLED` | `false` | Set to `true` to enable OpenID Connect / SSO login (Authelia, Authentik, Keycloak, etc.). |
-| `OIDC_ISSUER_URL` | — | Base URL of the OIDC provider (e.g. `https://auth.example.com`). |
+| `OIDC_ISSUER_URL` | — | Base URL of the OIDC provider (e.g. `https://auth.example.com`). **Must be `https`** — `http` is accepted only for `localhost`/`127.0.0.1`. Bindarr accepts the ID token on the strength of the TLS connection it arrives over rather than verifying its signature (permitted for the authorization-code flow by [OIDC Core §3.1.3.7](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation)), so plain HTTP would leave the identity unauthenticated. The discovery document's own `issuer` must also match this value. |
 | `OIDC_CLIENT_ID` | — | OIDC OAuth2 client ID. |
 | `OIDC_CLIENT_SECRET` | — | OIDC OAuth2 client secret. |
 | `OIDC_PROVIDER_NAME` | `Single Sign-On` | Display name shown on the login button (e.g. `Authelia`, `Authentik`, `Keycloak`). |

--- a/backend/src/utils/oidc.js
+++ b/backend/src/utils/oidc.js
@@ -66,6 +66,84 @@ function getIssuerUrl() {
   return (process.env.OIDC_ISSUER_URL || '').trim().replace(/\/+$/, '');
 }
 
+// Everything below trusts the transport instead of a signature: the ID token is
+// accepted because it came straight from the token endpoint over TLS, which is
+// what OIDC Core 3.1.3.7 allows in place of verifying it. Over plain http that
+// reasoning is worth nothing -- anything on the path can serve the discovery
+// document, be the token endpoint, and mint whatever identity it likes.
+//
+// Loopback is exempt because it never leaves the machine, and it is what the
+// test suite and a local IdP actually use.
+function assertIssuerTransport(issuer) {
+  let url;
+  try {
+    url = new URL(issuer);
+  } catch {
+    throw new Error(`OIDC_ISSUER_URL is not a valid URL: ${issuer}`);
+  }
+  if (url.protocol === 'https:') return;
+  if (url.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]', '::1'].includes(url.hostname)) return;
+  throw new Error(
+    `OIDC_ISSUER_URL must be https (got ${url.protocol}//${url.hostname}). ` +
+    'Identity is only as trustworthy as the connection it arrives over.'
+  );
+}
+
+// Bounded skew for exp. Clocks in a self-hosted stack drift, and refusing a
+// token that expired half a second ago by the container's reckoning is a
+// support ticket, not security.
+const CLOCK_SKEW_SECONDS = 60;
+
+// The checks the code flow still needs once the signature is taken on trust.
+//
+// Each one answers a question TLS does not:
+//   iss    -- did this come from the issuer we configured, or one whose discovery
+//             document happened to name someone else's token endpoint?
+//   aud    -- was it minted for THIS client, or replayed from another client of
+//             the same IdP that the caller also has an account with?
+//   exp    -- is it still current?
+//   nonce  -- is it the token minted for THIS login, or one captured earlier?
+//             buildAuthorizationUrl has always generated a nonce, sent it to the
+//             IdP and sealed it into the state token. Nothing ever compared it to
+//             the claim coming back, which meant it read as replay protection in
+//             review and was none.
+//
+// Throws on the first failure; the caller turns that into an oidc_error redirect.
+function validateIdTokenClaims(claims, { issuer, clientId, nonce, now = Date.now() } = {}) {
+  if (!claims || typeof claims !== 'object' || !Object.keys(claims).length) {
+    throw new Error('OIDC provider returned no ID token. The authorization code flow requires one.');
+  }
+
+  const strip = (v) => String(v || '').replace(/\/+$/, '');
+  if (issuer && strip(claims.iss) !== strip(issuer)) {
+    throw new Error(`OIDC ID token was issued by "${claims.iss}", not by the configured issuer.`);
+  }
+
+  // aud is a string, or an array when the IdP issues to several clients at once.
+  const audiences = Array.isArray(claims.aud) ? claims.aud.map(String) : [String(claims.aud || '')];
+  if (clientId && !audiences.includes(clientId)) {
+    throw new Error('OIDC ID token was not issued for this client.');
+  }
+  // With more than one audience the spec requires azp, and requires it to be us.
+  if (audiences.length > 1 && claims.azp && String(claims.azp) !== clientId) {
+    throw new Error('OIDC ID token was authorized for a different client.');
+  }
+
+  const exp = Number(claims.exp);
+  if (!Number.isFinite(exp)) {
+    throw new Error('OIDC ID token has no expiry.');
+  }
+  if (exp * 1000 + CLOCK_SKEW_SECONDS * 1000 < now) {
+    throw new Error('OIDC ID token has expired. Please try logging in again.');
+  }
+
+  if (nonce && String(claims.nonce || '') !== String(nonce)) {
+    throw new Error('OIDC ID token nonce does not match this login attempt.');
+  }
+
+  return claims;
+}
+
 function resolveRedirectUri(req) {
   if (process.env.OIDC_REDIRECT_URI) {
     return process.env.OIDC_REDIRECT_URI.trim();
@@ -111,6 +189,7 @@ async function getDiscovery(forceRefresh = false) {
   if (!issuer) {
     throw new Error('OIDC_ISSUER_URL is not configured');
   }
+  assertIssuerTransport(issuer);
 
   const now = Date.now();
   if (!forceRefresh && discoveryCache && discoveryExpiresAt > now) {
@@ -130,6 +209,15 @@ async function getDiscovery(forceRefresh = false) {
   const doc = await res.json();
   if (!doc.authorization_endpoint || !doc.token_endpoint) {
     throw new Error(`Invalid OIDC discovery response from ${discoveryUrl}: missing endpoints`);
+  }
+  // OIDC Discovery 4.3: the issuer the document claims must be the one we asked.
+  // Without this a redirect -- or anything that can answer for the host once --
+  // can hand back a document naming a token endpoint it controls, and every
+  // later check would then be measured against the attacker's own issuer.
+  if (String(doc.issuer || '').replace(/\/+$/, '') !== issuer) {
+    throw new Error(
+      `OIDC discovery at ${discoveryUrl} declares issuer "${doc.issuer}", which is not ${issuer}.`
+    );
   }
 
   discoveryCache = doc;
@@ -307,6 +395,13 @@ async function exchangeCode({ code, stateToken, req }) {
 
   const tokens = await tokenRes.json();
   const idTokenClaims = tokens.id_token ? parseJwtPayload(tokens.id_token) : {};
+  validateIdTokenClaims(idTokenClaims, {
+    issuer: discovery.issuer,
+    clientId,
+    // Sealed into the state token by buildAuthorizationUrl and carried through
+    // the IdP, so a token minted for some earlier login cannot be replayed here.
+    nonce: stateData.n
+  });
 
   // Fetch from userinfo endpoint if available to ensure all profile claims are present
   let userInfoClaims = {};
@@ -377,6 +472,8 @@ module.exports = {
   getDefaultRole,
   getUserClaimName,
   isUsernameLinkEnabled,
+  assertIssuerTransport,
+  validateIdTokenClaims,
   getTokenEndpointAuthMethod,
   getDiscovery,
   generatePkce,

--- a/backend/test/e2e/oidc.test.js
+++ b/backend/test/e2e/oidc.test.js
@@ -27,6 +27,8 @@ async function runTests() {
     preferred_username: 'PalletTownTrainer',
     email: 'trainer@pallet.org'
   };
+  // Echoed into the ID token, as a real IdP does with the nonce it was sent.
+  let currentNonce = null;
 
   const idpServer = http.createServer((req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
@@ -46,7 +48,13 @@ async function runTests() {
       let body = '';
       req.on('data', c => { body += c; });
       req.on('end', () => {
-        const payloadB64 = Buffer.from(JSON.stringify(mockUserClaims)).toString('base64url');
+        const payloadB64 = Buffer.from(JSON.stringify({
+          iss: `http://${req.headers.host}`,
+          aud: 'bindarr-test-id',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          nonce: currentNonce,
+          ...mockUserClaims
+        })).toString('base64url');
         const idToken = `eyJhbGciOiJub25lIn0.${payloadB64}.sig`;
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
@@ -114,6 +122,8 @@ async function runTests() {
     assert.strictEqual(authUrl.pathname, '/authorize');
     assert.strictEqual(authUrl.searchParams.get('client_id'), 'bindarr-test-id');
     const state = authUrl.searchParams.get('state');
+    currentNonce = authUrl.searchParams.get('nonce');
+    assert(currentNonce, 'the authorization request must carry a nonce');
     assert(state, 'state parameter must be present');
     console.log('PASS: F7-TC2');
 
@@ -148,7 +158,9 @@ async function runTests() {
       email: 'trainer@pallet.org'
     };
     const loginRes2 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
-    const state2 = new URL(loginRes2.headers.get('location')).searchParams.get('state');
+    const authUrl2 = new URL(loginRes2.headers.get('location'));
+    const state2 = authUrl2.searchParams.get('state');
+    currentNonce = authUrl2.searchParams.get('nonce');
     const callbackRes2 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-2&state=${encodeURIComponent(state2)}`, {
       redirect: 'manual'
     });
@@ -165,7 +177,9 @@ async function runTests() {
 
     // F7-TC6: Repeated login with same sub logs into existing member without duplicating rows
     const loginRes3 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
-    const state3 = new URL(loginRes3.headers.get('location')).searchParams.get('state');
+    const authUrl3 = new URL(loginRes3.headers.get('location'));
+    const state3 = authUrl3.searchParams.get('state');
+    currentNonce = authUrl3.searchParams.get('nonce');
     const callbackRes3 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-3&state=${encodeURIComponent(state3)}`, {
       redirect: 'manual'
     });
@@ -200,7 +214,9 @@ async function runTests() {
       email: 'attacker@example.invalid'
     };
     const loginRes4 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
-    const state4 = new URL(loginRes4.headers.get('location')).searchParams.get('state');
+    const authUrl4 = new URL(loginRes4.headers.get('location'));
+    const state4 = authUrl4.searchParams.get('state');
+    currentNonce = authUrl4.searchParams.get('nonce');
     const callbackRes4 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-4&state=${encodeURIComponent(state4)}`, {
       redirect: 'manual'
     });
@@ -218,7 +234,9 @@ async function runTests() {
       email: 'owner@pallet.org'
     };
     const loginRes5 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
-    const state5 = new URL(loginRes5.headers.get('location')).searchParams.get('state');
+    const authUrl5 = new URL(loginRes5.headers.get('location'));
+    const state5 = authUrl5.searchParams.get('state');
+    currentNonce = authUrl5.searchParams.get('nonce');
     const callbackRes5 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-5&state=${encodeURIComponent(state5)}`, {
       redirect: 'manual'
     });
@@ -230,6 +248,32 @@ async function runTests() {
     assert.strictEqual(ownerMe.user.id, meData.user.id, 'must still be the same owner account');
     assert.strictEqual(ownerMe.user.oidc_sub, 'idp-sub-777', 'the attacker must not have re-bound the owner');
     console.log('PASS: F7-TC8');
+
+    // F7-TC11: an ID token minted for a DIFFERENT login is refused.
+    //
+    // buildAuthorizationUrl has always generated a nonce, sent it to the IdP and
+    // sealed it into the signed state token. Nothing ever compared it to the
+    // claim that came back, so a token captured from an earlier exchange was as
+    // good as a fresh one. This drives the real route rather than the validator
+    // directly, because the bug was never in the checking -- it was that no one
+    // called it.
+    mockUserClaims = {
+      sub: 'idp-sub-777',
+      preferred_username: 'admin',
+      email: 'owner@pallet.org'
+    };
+    const loginRes6 = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
+    const authUrl6 = new URL(loginRes6.headers.get('location'));
+    const state6 = authUrl6.searchParams.get('state');
+    // The IdP answers with the nonce from some other login, not this one.
+    currentNonce = 'a-nonce-from-a-different-login';
+    const callbackRes6 = await fetch(`${base}/api/auth/oidc/callback?code=valid-auth-code-6&state=${encodeURIComponent(state6)}`, {
+      redirect: 'manual'
+    });
+    const replay = new URL(callbackRes6.headers.get('location'), base).searchParams;
+    assert.strictEqual(replay.get('oidc_token'), null, 'a mismatched nonce must not issue a session');
+    assert(/nonce/i.test(replay.get('oidc_error') || ''), 'the refusal must name the nonce');
+    console.log('PASS: F7-TC11');
 
   } finally {
     server.kill('SIGKILL');
@@ -254,6 +298,7 @@ async function runUsernameLinkTests() {
     preferred_username: 'admin',
     email: 'owner@pallet.org'
   };
+  let currentNonce = null;
 
   const idpServer = http.createServer((req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
@@ -270,7 +315,13 @@ async function runUsernameLinkTests() {
     if (url.pathname === '/token' && req.method === 'POST') {
       req.on('data', () => {});
       req.on('end', () => {
-        const payloadB64 = Buffer.from(JSON.stringify(mockUserClaims)).toString('base64url');
+        const payloadB64 = Buffer.from(JSON.stringify({
+          iss: `http://${req.headers.host}`,
+          aud: 'bindarr-test-id',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          nonce: currentNonce,
+          ...mockUserClaims
+        })).toString('base64url');
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           access_token: 'mock-access-token',
@@ -315,7 +366,9 @@ async function runUsernameLinkTests() {
 
   const callback = async (code) => {
     const loginRes = await fetch(`${base}/api/auth/oidc/login`, { redirect: 'manual' });
-    const state = new URL(loginRes.headers.get('location')).searchParams.get('state');
+    const authUrl = new URL(loginRes.headers.get('location'));
+    const state = authUrl.searchParams.get('state');
+    currentNonce = authUrl.searchParams.get('nonce');
     const res = await fetch(`${base}/api/auth/oidc/callback?code=${code}&state=${encodeURIComponent(state)}`, {
       redirect: 'manual'
     });

--- a/backend/test/oidc.test.js
+++ b/backend/test/oidc.test.js
@@ -73,10 +73,87 @@ function testExtractUserIdentity() {
   console.log('PASS: User claim extraction, normalization, and sanitization');
 }
 
+function testIssuerTransport() {
+  const { assertIssuerTransport } = oidc;
+
+  // https is the only thing good enough on a real network. The ID token is
+  // accepted on the strength of the connection it arrived over, so a plain-http
+  // issuer means anything on the path can be the identity provider.
+  assert.doesNotThrow(() => assertIssuerTransport('https://auth.example.com'));
+  assert.throws(() => assertIssuerTransport('http://auth.example.com'), /must be https/);
+
+  // Loopback never leaves the machine, and is what a local IdP and this suite use.
+  assert.doesNotThrow(() => assertIssuerTransport('http://localhost:9000'));
+  assert.doesNotThrow(() => assertIssuerTransport('http://127.0.0.1:9000'));
+
+  assert.throws(() => assertIssuerTransport('not a url'), /not a valid URL/);
+  console.log('PASS: issuer transport must be https or loopback');
+}
+
+function testIdTokenValidation() {
+  const { validateIdTokenClaims } = oidc;
+  const ISS = 'https://auth.example.com';
+  const CID = 'bindarr';
+  const NONCE = 'nonce-abc';
+  const ok = () => ({
+    iss: ISS,
+    aud: CID,
+    exp: Math.floor(Date.now() / 1000) + 600,
+    nonce: NONCE,
+    sub: 'user-1'
+  });
+  const check = (claims) => validateIdTokenClaims(claims, { issuer: ISS, clientId: CID, nonce: NONCE });
+
+  assert.doesNotThrow(() => check(ok()), 'a well-formed token must pass');
+
+  // No ID token at all. The authorization-code flow always returns one, so an
+  // empty object means something is wrong, not that there is nothing to check.
+  assert.throws(() => check({}), /no ID token/);
+  assert.throws(() => check(null), /no ID token/);
+
+  // iss: a discovery document naming someone else's token endpoint is the whole
+  // reason this is checked rather than assumed.
+  assert.throws(() => check({ ...ok(), iss: 'https://evil.example.com' }), /issued by/);
+  // A trailing slash is the same issuer, not a different one.
+  assert.doesNotThrow(() => check({ ...ok(), iss: ISS + '/' }));
+
+  // aud: a token minted for another client of the same IdP must not be replayable
+  // here, even though it is perfectly valid and correctly signed.
+  assert.throws(() => check({ ...ok(), aud: 'some-other-app' }), /not issued for this client/);
+  assert.doesNotThrow(() => check({ ...ok(), aud: ['some-other-app', CID] }),
+    'an array audience containing us is fine');
+  // Several audiences: azp says which one it was actually authorized for.
+  assert.throws(() => check({ ...ok(), aud: [CID, 'other'], azp: 'other' }), /different client/);
+  assert.doesNotThrow(() => check({ ...ok(), aud: [CID, 'other'], azp: CID }));
+
+  // exp
+  assert.throws(() => check({ ...ok(), exp: undefined }), /no expiry/);
+  assert.throws(() => check({ ...ok(), exp: Math.floor(Date.now() / 1000) - 3600 }), /expired/);
+  // Container clocks drift; a token that died two seconds ago is a support
+  // ticket, not an attack.
+  assert.doesNotThrow(() => check({ ...ok(), exp: Math.floor(Date.now() / 1000) - 2 }),
+    'a small clock skew must be tolerated');
+
+  // nonce: generated, sent and sealed into the state token since day one, and
+  // never once compared to what came back.
+  assert.throws(() => check({ ...ok(), nonce: 'a-different-login' }), /nonce does not match/);
+  assert.throws(() => check({ ...ok(), nonce: undefined }), /nonce does not match/);
+  // Nothing to compare against: no nonce was requested, so none is required.
+  assert.doesNotThrow(() => validateIdTokenClaims(
+    { ...ok(), nonce: undefined }, { issuer: ISS, clientId: CID }
+  ));
+
+  console.log('PASS: ID token iss/aud/exp/nonce validation');
+}
+
 async function testMockOidcFlow() {
   // Start temporary mock OIDC server
   let authCodeReceived = null;
   let codeVerifierReceived = null;
+  // The nonce the client asked for, echoed back in the ID token exactly as a
+  // real IdP does. Nothing verified this before -- the mock did not even send
+  // one -- so the test passed against a client that never looked.
+  let currentNonce = null;
 
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
@@ -101,6 +178,10 @@ async function testMockOidcFlow() {
         codeVerifierReceived = params.get('code_verifier');
 
         const mockIdTokenPayload = {
+          iss: `http://${req.headers.host}`,
+          aud: 'bindarr-test-client',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          nonce: currentNonce,
           sub: 'auth-user-999',
           preferred_username: 'RedChampion',
           email: 'red@kanto.org'
@@ -143,6 +224,8 @@ async function testMockOidcFlow() {
 
     const stateToken = parsedAuth.searchParams.get('state');
     assert(stateToken, 'state param must be set');
+    currentNonce = parsedAuth.searchParams.get('nonce');
+    assert(currentNonce, 'nonce param must be set');
 
     // 2. Test exchangeCode
     const exchangeResult = await oidc.exchangeCode({
@@ -169,6 +252,8 @@ async function main() {
   testPkce();
   testStateTokens();
   testExtractUserIdentity();
+  testIssuerTransport();
+  testIdTokenValidation();
   await testMockOidcFlow();
   console.log('PASS: oidc.test.js');
 }


### PR DESCRIPTION
Refs #43. Follow-up to #45/#55, closing the gap noted at the bottom of #55.

## What was missing

`exchangeCode` base64-decoded the ID token payload and used it:

```js
const idTokenClaims = tokens.id_token ? parseJwtPayload(tokens.id_token) : {};
```

`parseJwtPayload` is a `JSON.parse` of the middle segment. Nothing checked who issued the token, who it was for, whether it had expired, or whether it belonged to the login in progress.

## What this does not do

It still does not verify the signature, and that is deliberate. The token comes straight from the token endpoint over a direct TLS back-channel, which [OIDC Core §3.1.3.7](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation) explicitly allows as a substitute for verification. Fetching JWKS, caching it, handling rotation and supporting RS256/ES256 is a few hundred lines against a threat the transport already covers.

The four checks below are the ones §3.1.3.7 does **not** cover. They are fifteen lines.

## The four checks

**`nonce` — the one that matters.** `buildAuthorizationUrl` has always generated a nonce, sent it to the IdP and sealed it into the signed state token. Nothing ever compared it to the claim coming back. A nonce that is generated and never checked is worse than no nonce: it reads as replay protection in review and provides none.

**`iss`.** A discovery document naming someone else's token endpoint would have gone unnoticed. `getDiscovery` now also enforces [Discovery §4.3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation) — the document's own `issuer` must be the one we asked for — so this check has something honest to measure against.

**`aud`.** A valid, correctly signed token minted for a *different* client of the same IdP was accepted here. Handles string and array audiences, and checks `azp` when there is more than one.

**`exp`.** Not checked at all. 60s of skew is allowed — container clocks drift, and a token that died two seconds ago is a support ticket, not an attack.

**Plus:** `OIDC_ISSUER_URL` must now be `https`, loopback excepted. All four rest on the connection being trustworthy; over plain HTTP none of them mean anything. Documented in the README row.

## Verification

`validateIdTokenClaims` and `assertIssuerTransport` are exported and unit-tested in `backend/test/oidc.test.js`: every claim, plus array audiences, `azp` mismatch, trailing-slash issuers, a missing ID token, and both sides of the clock-skew window.

The route-level case is **F7-TC11**, which drives the real callback with an ID token minted for a different login and asserts no session comes back. That one is e2e on purpose — the bug was never in the checking, it was that nothing called it. Reverting `oidc.js` fails it:

```
FAIL: oidc.test.js - a mismatched nonce must not issue a session
```

Both mock IdPs now issue spec-shaped tokens with `iss`, `aud`, `exp` and the nonce they were sent, which is what they should always have done — the old mocks would have passed against a client that checked nothing, which is exactly what happened.

`npm test`: 38/38 unit files, 6/6 e2e suites, 43/43 cases. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)