### PR TITLE
chore(pokemon): warn at boot when the install is still on pokemontcg.io

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -25,6 +25,23 @@ const pokemonSetSource = async () =>
     ? require('./tcgdexApi')
     : tcgApi;
 
+// Say the provider deprecation out loud at boot, to the installs it applies to.
+//
+// It is written down everywhere already — README, .env.example, the Admin
+// provider hint — and none of that reaches the person who set this up two years
+// ago and has not opened Settings since. The startup log is what a self-hoster
+// actually reads, and it is where they will be looking the morning it breaks.
+//
+// The decision lives in utils/pokemonProvider with the rest of the provider
+// policy; this only prints it.
+async function warnIfProviderSunsetting() {
+  try {
+    const provider = require('./utils/pokemonProvider');
+    const notice = provider.sunsetNotice(await provider.configured());
+    if (notice) console.warn(notice);
+  } catch { /* a boot-time notice must never be the thing that stops the boot */ }
+}
+
 const authRoutes = require('./routes/auth');
 const sharedRoutes = require('./routes/shared');
 const adminRoutes = require('./routes/admin');
@@ -244,6 +261,14 @@ db.initDb()
     await (await pokemonSetSource()).fetchAndCacheSets();
     await scryfallApi.fetchAndCacheSets();
     await lorcastApi.fetchAndCacheSets();
+
+    // pokemontcg.io has an end date, and static documentation does not reach
+    // someone who set this up two years ago and has not opened Settings since.
+    // The startup log is the surface self-hosters actually read, so say it there
+    // — once per boot, only to the installs it applies to, and only until the
+    // date passes, after which it is no longer a warning but a description of
+    // why things stopped working, which the provider's own errors will cover.
+    await warnIfProviderSunsetting();
 
     // Load sets into compartmentSort memory cache
     const { loadSetsCache } = require('./utils/compartmentSort');

--- a/backend/src/utils/pokemonProvider.js
+++ b/backend/src/utils/pokemonProvider.js
@@ -60,4 +60,25 @@ async function usesTcgdex(lang) {
   return (await providerFor(lang)) === TCGDEX;
 }
 
-module.exports = { decide, configured, providerFor, usesTcgdex, TCGDEX, POKEMONTCG };
+// pokemontcg.io is being retired by its operator: new API-key registrations are
+// already closed, and existing keys stop working on this date.
+const POKEMONTCG_SUNSET = '2027-03-01';
+
+// The boot warning, as a value rather than a side effect, so the two things
+// that are easy to get wrong can be tested: it must be silent for installs the
+// deprecation does not apply to, and silent again once the date has passed —
+// after that it is not a warning, it is an explanation, and the provider's own
+// errors give a better one than a line at startup can.
+//
+// Returns null when there is nothing to say.
+function sunsetNotice(provider, now = Date.now()) {
+  if (provider !== POKEMONTCG) return null;
+  const sunset = Date.parse(`${POKEMONTCG_SUNSET}T00:00:00Z`);
+  if (now >= sunset) return null;
+  const days = Math.ceil((sunset - now) / 86400000);
+  return `Pokémon provider is pokemontcg.io, which stops serving on ${POKEMONTCG_SUNSET} (${days} days).`
+    + ' New API keys can no longer be registered. Switch to TCGdex in Admin → Instance Settings;'
+    + ' it needs no key, and cards already cached keep working.';
+}
+
+module.exports = { decide, configured, providerFor, usesTcgdex, sunsetNotice, POKEMONTCG_SUNSET, TCGDEX, POKEMONTCG };

--- a/backend/test/pokemonprovider.test.js
+++ b/backend/test/pokemonprovider.test.js
@@ -17,7 +17,7 @@ const path = require('path');
 
 process.env.DB_PATH = path.join(os.tmpdir(), `bindarr-provider-${process.pid}.db`);
 const cardSets = require('../src/cardSets');
-const { decide, TCGDEX, POKEMONTCG } = require('../src/utils/pokemonProvider');
+const { decide, sunsetNotice, POKEMONTCG_SUNSET, TCGDEX, POKEMONTCG } = require('../src/utils/pokemonProvider');
 
 function testLanguageVeto() {
   // pokemontcg.io has no non-English cards at all, so the SETTING CANNOT WIN here.
@@ -118,12 +118,45 @@ function testIdDispatchIsAboutTheIdNotTheSetting() {
   }
 }
 
+
+// The boot warning about pokemontcg.io being retired.
+//
+// Two ways for a notice like this to go wrong, and both are silent: shouting at
+// installs it does not apply to, and still shouting years after the date has
+// passed. Neither shows up in normal use — the first is someone else's log, the
+// second is a date nobody re-reads — so they are pinned here.
+function testSunsetNotice() {
+  const beforeSunset = Date.parse(`${POKEMONTCG_SUNSET}T00:00:00Z`) - 30 * 86400000;
+  const afterSunset = Date.parse(`${POKEMONTCG_SUNSET}T00:00:00Z`) + 86400000;
+
+  // The install it applies to: still on pokemontcg.io, date not yet reached.
+  const notice = sunsetNotice(POKEMONTCG, beforeSunset);
+  assert(notice, 'an install still on pokemontcg.io must be warned');
+  assert(notice.includes(POKEMONTCG_SUNSET), 'the notice must name the date');
+  assert(/30 days/.test(notice), 'the notice must say how long is left');
+  assert(/TCGdex/.test(notice), 'the notice must name the way out');
+
+  // Not their problem: TCGdex installs hear nothing.
+  assert.strictEqual(sunsetNotice(TCGDEX, beforeSunset), null,
+    'a TCGdex install has nothing to be warned about');
+
+  // Past the date it stops being a warning. The provider's own failures explain
+  // it better than a line at boot, and a countdown that has run out is noise on
+  // every restart forever.
+  assert.strictEqual(sunsetNotice(POKEMONTCG, afterSunset), null,
+    'the warning must stop once the date has passed');
+
+  // Exactly at the boundary counts as passed.
+  assert.strictEqual(sunsetNotice(POKEMONTCG, Date.parse(`${POKEMONTCG_SUNSET}T00:00:00Z`)), null);
+}
+
 async function main() {
   testIdDispatchIsAboutTheIdNotTheSetting();
   testLanguageVeto();
   testUnknownLanguageDegradesToEnglish();
   testEnglishFollowsTheSetting();
   testUnknownSettingIsSafe();
+  testSunsetNotice();
   await testNoSecondSourceOfTruth();
   console.log('pokemonprovider.test.js: all assertions passed');
 }


### PR DESCRIPTION
Closes #50.

## Why, given #54 already fixed the docs

pokemontcg.io stops serving on **2027-03-01** and new API-key registrations are already closed. #54 wrote that down in the README, `.env.example`, `docker-compose.yml`, Settings and the Admin provider hint.

None of those reach the person who set Bindarr up two years ago and has not opened Settings since. They are not going to re-read the README. The startup log is the surface a self-hoster actually reads, and it is where they will be looking the morning it breaks.

## What it does

One line at boot, only for installs whose provider is pokemontcg.io, with a live count of the days remaining and the one-step way out:

```
Pokémon provider is pokemontcg.io, which stops serving on 2027-03-01 (172 days).
New API keys can no longer be registered. Switch to TCGdex in Admin → Instance
Settings; it needs no key, and cards already cached keep working.
```

It sits next to the existing `Skipping background price update: No global POKEMON_TCG_API_KEY configured` line, in the same register.

## Where the logic lives

`sunsetNotice(provider, now)` in `utils/pokemonProvider`, with the rest of the provider policy, rather than inline in `server.js`. `server.js` only prints what it returns.

That is not abstraction for its own sake — the two ways a notice like this goes wrong are both silent, and both are worth pinning:

- shouting at installs it does not apply to (a TCGdex user's log)
- still shouting years after the date has passed (a countdown that ran out, on every restart, forever)

It returns `null` for both, and at the exact boundary too. All four cases are asserted in `backend/test/pokemonprovider.test.js`.

## Verified end to end

Booted a server twice against the same database — silent on the fresh install (which defaults to TCGdex), and after switching `pokemon_provider` to `pokemontcg` the second boot printed the line above, with the day count correct for today's date.

`npm test`: 38/38 unit files, 6/6 e2e suites, 42/42 cases.

## Not included

An Admin banner. The log line is the one that reaches the audience this is for, and a dated banner in the UI is a second thing to remember to delete in March 2027. Easy to add later if you want it.

No README change either — #54 already covers it there, and #52 adds a "Pokémon data providers" section to the same area, so leaving it alone keeps that rebase smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)