### PR TITLE
perf(pokemon): only refresh prices for cards that are actually stale

### DIFF
--- a/backend/src/tcgApi.js
+++ b/backend/src/tcgApi.js
@@ -35,6 +35,19 @@ tcgClient.interceptors.response.use(null, async (error) => {
 });
 
 // Helper: Extract a single representative price from card data
+// How long a cached card is considered current. Referenced from three places --
+// searchCards, getCardById and the price sweep -- and the sweep now selects on
+// it in SQL, so it has to be one number rather than three copies. Two that
+// disagree would have the sweep pick cards getCardById then refuses to refresh:
+// a loop that runs for an hour and changes nothing, silently.
+const CACHE_AGE_LIMIT_DAYS = 3;
+const CACHE_AGE_LIMIT_MS = 1000 * 60 * 60 * 24 * CACHE_AGE_LIMIT_DAYS;
+
+// Spacing between price requests. pokemontcg.io allows 20,000 a day with a key,
+// so this is politeness rather than a limit the sweep is anywhere near.
+// Overridable so the test suite need not spend a real second per card.
+const PRICE_REQUEST_GAP_MS = Number(process.env.POKEMON_PRICE_GAP_MS || 1000);
+
 function extractPrice(card) {
   if (card.tcgplayer && card.tcgplayer.prices) {
     const pricesObj = card.tcgplayer.prices;
@@ -313,8 +326,7 @@ async function runSearch(meta, nameQuery = '', numberQuery = '', setQuery = '', 
     // If we found local results and they are not empty, return them instantly.
     // Stale prices (older than 3 days) are updated asynchronously in the background.
     if (localResults.length > 0) {
-      const cacheAgeLimit = 1000 * 60 * 60 * 24 * 3; // 3 days
-      const staleCards = localResults.filter(r => (new Date() - new Date(r.last_updated) > cacheAgeLimit));
+      const staleCards = localResults.filter(r => (new Date() - new Date(r.last_updated) > CACHE_AGE_LIMIT_MS));
       const hasKey = apiKey || process.env.POKEMON_TCG_API_KEY;
       if (staleCards.length > 0 && hasKey) {
         (async () => {
@@ -490,9 +502,8 @@ async function getCardById(id, apiKey = '') {
     return cached ? parseCardRow(cached) : null;
   }
 
-  // If cached and fresh (e.g. within 3 days), return it
-  const cacheAgeLimit = 1000 * 60 * 60 * 24 * 3; // 3 days
-  if (cached && (new Date() - new Date(cached.last_updated) < cacheAgeLimit)) {
+  // If cached and fresh, return it — no request, no rate limit spent.
+  if (cached && (new Date() - new Date(cached.last_updated) < CACHE_AGE_LIMIT_MS)) {
     return parseCardRow(cached);
   }
 
@@ -603,22 +614,43 @@ async function updateCollectionPrices(force = false) {
   }
 
   try {
-    // Select unique Pokémon card IDs from both collections (owned and wishlist)
-    // and decks. MTG cards are excluded — they refresh via Scryfall on search,
-    // and hitting the Pokémon API for an "mtg-" id would just 404.
-    // English only — non-English Pokémon rows come from TCGdex and are swept by
-    // tcgdexApi.updateCollectionPrices, so asking pokemontcg.io about them would
-    // burn a second of rate limit per card to get a 404.
+    // Owned and decked Pokémon cards that are actually STALE.
+    //
+    // The staleness clause is the point. This used to select every owned card and
+    // hand each one to getCardById, which returns the cached row untouched when it
+    // is under CACHE_AGE_LIMIT_DAYS old -- and then slept a second regardless of
+    // whether a request had been made. The sweep runs daily against a three-day
+    // cache, so on two days out of three it made almost no requests and still took
+    // one second per owned card to make them: on a 5,000-card collection that is
+    // 83 minutes of a container doing nothing but setTimeout. Now the days with
+    // nothing to do cost nothing, and the second between requests is spent only
+    // where there is a request to space out.
+    //
+    // MTG is excluded — it refreshes via Scryfall on search, and asking
+    // pokemontcg.io about an "mtg-" id would just 404. English only — non-English
+    // Pokémon rows come from TCGdex and are swept by its own updateCollectionPrices.
+    //
+    // Driven from collection/deck_cards and joined to card_cache by primary key,
+    // which is what keeps the added clause cheap; see #49 for the shape to avoid.
+    const staleClause = `cc.game = 'pokemon' AND cc.language = 'English'
+        AND (cc.last_updated IS NULL OR cc.last_updated <= datetime('now', '-${CACHE_AGE_LIMIT_DAYS} days'))`;
     const cardsInUse = await db.all(`
       SELECT DISTINCT c.card_id FROM collection c
-      JOIN card_cache cc ON c.card_id = cc.id WHERE cc.game = 'pokemon' AND cc.language = 'English'
+      JOIN card_cache cc ON c.card_id = cc.id WHERE ${staleClause}
       UNION
       SELECT DISTINCT d.card_id FROM deck_cards d
-      JOIN card_cache cc ON d.card_id = cc.id WHERE cc.game = 'pokemon' AND cc.language = 'English'
+      JOIN card_cache cc ON d.card_id = cc.id WHERE ${staleClause}
     `);
-    
-    console.log(`Starting background price update for ${cardsInUse.length} unique cards...`);
-    for (const item of cardsInUse) {
+
+    if (!cardsInUse.length) {
+      await markPricesSwept('pokemon');
+      console.log('Pokémon price update: every owned card is current, nothing to fetch.');
+      return;
+    }
+
+    console.log(`Starting background price update for ${cardsInUse.length} stale cards...`);
+    for (let i = 0; i < cardsInUse.length; i++) {
+      const item = cardsInUse[i];
       try {
         // Fetching will force update the cache and price
         const updatedCard = await getCardById(item.card_id, process.env.POKEMON_TCG_API_KEY);
@@ -627,8 +659,9 @@ async function updateCollectionPrices(force = false) {
       } catch (itemErr) {
         console.error(`Failed to update price for card ${item.card_id}:`, itemErr.message);
       }
-      // Wait 1 second between requests to respect API rate limits
-      await new Promise(r => setTimeout(r, 1000));
+      // A second between requests, to respect the rate limit. Between, not after:
+      // the old loop also paid it once the last card was already done.
+      if (i < cardsInUse.length - 1) await new Promise(r => setTimeout(r, PRICE_REQUEST_GAP_MS));
     }
     await markPricesSwept('pokemon');
     console.log('Background price update complete.');

--- a/backend/test/pricesweep.test.js
+++ b/backend/test/pricesweep.test.js
@@ -1,0 +1,152 @@
+// The daily Pokémon price sweep, and the two things it used to get wrong.
+//
+// It selected every owned English Pokémon card and handed each one to
+// getCardById. That returns the cached row untouched when it is less than three
+// days old — so on a daily sweep against a three-day cache, most days it made
+// almost no requests. It then slept a second per card regardless, which meant a
+// 5,000-card collection spent 83 minutes a day in setTimeout to fetch nothing.
+//
+// Two assertions, and neither can be made by reading the code: how many requests
+// reach the provider, and how long the sweep takes relative to the number of
+// cards it actually had work for.
+//
+// No framework — plain node + assert. Run: `node test/pricesweep.test.js`
+const assert = require('assert');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+process.env.DB_PATH = path.join(os.tmpdir(), `bindarr-pricesweep-${process.pid}.db`);
+process.env.POKEMON_TCG_API_KEY = 'test-key';
+// initDb only seeds the 'admin' user when a password is pinned, and collection
+// rows carry a user_id that references it.
+process.env.DEFAULT_ADMIN_PASSWORD = 'test-admin-password';
+// The real gap is a second per request. The point here is that it is paid per
+// REQUEST rather than per owned card, which a smaller gap measures just as well
+// and 30 seconds faster.
+process.env.POKEMON_PRICE_GAP_MS = '40';
+
+const db = require('../src/db');
+const { updateCollectionPrices, tcgClient } = require('../src/tcgApi');
+
+// Stand-in for api.pokemontcg.io. Counts what actually reaches it.
+function makeServer(state) {
+  return http.createServer((req, res) => {
+    state.hits++;
+    const id = decodeURIComponent(req.url.split('/cards/')[1] || '').split('?')[0];
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        id,
+        name: 'Test Card',
+        number: '1',
+        set: { id: 'test', name: 'Test Set' },
+        images: { small: 'https://img/small.png' },
+        tcgplayer: { prices: { normal: { market: 1.23 } } },
+      },
+    }));
+  });
+}
+
+const listen = (server) => new Promise(resolve =>
+  server.listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${server.address().port}`)));
+
+// `fresh` cards were cached just now; `stale` ones four days ago. Only the stale
+// ones have anything to fetch.
+async function seed({ fresh, stale }) {
+  await db.run(`DELETE FROM collection`);
+  await db.run(`DELETE FROM card_cache`);
+  await db.run(`DELETE FROM price_sweeps`).catch(() => {});
+  let n = 0;
+  const add = async (count, when) => {
+    for (let i = 0; i < count; i++) {
+      const id = `sv1-${++n}`;
+      await db.run(
+        `INSERT INTO card_cache (id, name, set_id, number, game, language, price_trend, last_updated)
+         VALUES (?, ?, ?, ?, 'pokemon', 'English', 1.0, ${when})`,
+        [id, `Card ${n}`, 'sv1', String(n)]
+      );
+      await db.run(
+        `INSERT INTO collection (user_id, card_id, quantity, condition) VALUES (1, ?, 1, 'Near Mint')`,
+        [id]
+      );
+    }
+  };
+  await add(fresh, `datetime('now')`);
+  await add(stale, `datetime('now', '-4 days')`);
+}
+
+async function main() {
+  await db.initDb();
+
+  // --- 1. Nothing stale: no requests, and no time spent pretending. ----------
+  {
+    const state = { hits: 0 };
+    const server = makeServer(state);
+    tcgClient.defaults.baseURL = await listen(server);
+    try {
+      await seed({ fresh: 40, stale: 0 });
+      const t0 = Date.now();
+      await updateCollectionPrices(true);
+      const ms = Date.now() - t0;
+
+      assert.strictEqual(state.hits, 0, 'cards cached today must not be re-fetched');
+      // The old loop slept POKEMON_PRICE_GAP_MS per owned card whether or not it
+      // fetched anything: 40 cards, 40 gaps. Anything near that is the bug back.
+      assert.ok(ms < 20 * Number(process.env.POKEMON_PRICE_GAP_MS),
+        `a sweep with nothing to do took ${ms}ms — it is still sleeping per owned card`);
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  }
+
+  // --- 2. Some stale: exactly those are fetched, and priced. -----------------
+  {
+    const state = { hits: 0 };
+    const server = makeServer(state);
+    tcgClient.defaults.baseURL = await listen(server);
+    try {
+      await seed({ fresh: 30, stale: 5 });
+      await updateCollectionPrices(true);
+
+      assert.strictEqual(state.hits, 5,
+        `expected one request per STALE card, got ${state.hits} for 5 stale of 35 owned`);
+
+      // The fetched rows really were written back, or "refreshed" means nothing.
+      const priced = await db.get(
+        `SELECT COUNT(*) n FROM card_cache
+          WHERE game = 'pokemon' AND price_trend = 1.23 AND last_updated > datetime('now', '-1 day')`
+      );
+      assert.strictEqual(priced.n, 5, 'every stale card must come back with its new price');
+
+      // And a price series row for each, since the price moved 1.00 -> 1.23.
+      const history = await db.get(`SELECT COUNT(*) n FROM price_history`);
+      assert.strictEqual(history.n, 5, 'a price movement must be recorded once per card');
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  }
+
+  // --- 3. The gap is paid BETWEEN requests, not after the last one. ----------
+  {
+    const state = { hits: 0 };
+    const server = makeServer(state);
+    tcgClient.defaults.baseURL = await listen(server);
+    try {
+      await seed({ fresh: 0, stale: 1 });
+      const t0 = Date.now();
+      await updateCollectionPrices(true);
+      const ms = Date.now() - t0;
+
+      assert.strictEqual(state.hits, 1);
+      assert.ok(ms < Number(process.env.POKEMON_PRICE_GAP_MS),
+        `one card took ${ms}ms — the sweep is still sleeping after the last request`);
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  }
+
+  console.log('pricesweep.test.js: all 7 assertions passed');
+}
+
+main().then(() => process.exit(0)).catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## The bug

The daily price sweep selected **every** owned and decked English Pokémon card and handed each one to `getCardById`. That function returns the cached row untouched when it is under three days old — no HTTP request. Then the loop slept a second anyway, outside the branch that decides whether to fetch:

```js
for (const item of cardsInUse) {
  const updatedCard = await getCardById(item.card_id, KEY);   // often a no-op
  if (updatedCard) await recordPrice(item.card_id, updatedCard.price_trend);
  await new Promise(r => setTimeout(r, 1000));                // always paid
}
```

So against a three-day cache and a daily sweep, on two days out of three it made almost no requests and still charged a second per owned card for the privilege.

**Measured**, on the old code, 40 owned cards all cached today:

```
0 requests, 40,782 ms
```

Extrapolated: a 5,000-card collection spends **83 minutes a day** in `setTimeout` fetching nothing. 15,000 cards, four hours.

## The fix

**1. Select only stale cards.** The clause hangs off the existing query, which drives from `collection`/`deck_cards` and joins `card_cache` by primary key — deliberately *not* the correlated shape that caused #49.

```sql
AND (cc.last_updated IS NULL OR cc.last_updated <= datetime('now', '-3 days'))
```

A day with nothing to refresh now returns immediately.

**2. Gap between requests, not after every card** — and the last request no longer pays it on the way out.

**3. One constant.** The three-day limit was written out three times (`searchCards`, `getCardById`, and now the sweep's SQL). Copies that drift would have the sweep select cards `getCardById` then declines to refresh: a loop that runs for an hour, changes nothing, and logs nothing about it. It is `CACHE_AGE_LIMIT_DAYS` now.

## Verification

New `backend/test/pricesweep.test.js` — a local stand-in for api.pokemontcg.io that counts what actually reaches it. Three cases, seven assertions:

| | |
|---|---|
| 40 fresh, 0 stale | 0 requests, and the sweep must not take 40 gaps' worth of time |
| 30 fresh, 5 stale | exactly 5 requests; all 5 written back with the new price; 5 price-history rows |
| 1 stale | 1 request, and under one gap of wall clock |

Reverting `tcgApi.js` fails it with the measurement quoted above:

```
AssertionError: a sweep with nothing to do took 40782ms — it is still sleeping per owned card
```

The test itself runs in 1.4s. `npm test`: 39/39 unit files, 6/6 e2e suites, 43/43 cases.

## What this deliberately does not do

**Batching.** pokemontcg.io accepts `q=id:a OR id:b ...` with `pageSize` up to 250, and `tcgApi` already uses that syntax for set fetches ([`getCardsBySet`](https://github.com/thenotoriousJeremy/bindarr/blob/main/backend/src/tcgApi.js)). On the third day, when the whole collection goes stale at once, that would turn 5,000 requests into ~50.

I have not done it because **nobody here can verify it**. This install has no `POKEMON_TCG_API_KEY`, registrations are closed, and the provider stops serving on 2027-03-01. Rewriting a price path against an API we cannot test, for eighteen months of remaining life, is a bad trade. If someone holding a key wants to try it, the change is about twenty lines and this test file already has the harness for it.

**The non-English (TCGdex) sweep** is untouched. It is also one request per card, but concurrent rather than serial, and TCGdex is free — so it costs wall clock and politeness, not money, and TCGdex has no bulk endpoint to move to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)